### PR TITLE
Let queue creation have one thread

### DIFF
--- a/app/indexer.cpp
+++ b/app/indexer.cpp
@@ -224,7 +224,7 @@ int indexer::start_from() {
 					batch_queue_added_size[batch_queue_add_start + batch_queue_current] += filesize;
 					added = true;
 				}
-				if (batch_queue_current + 1 == threads_to_use - 1) {
+				if (batch_queue_current + 1 == threads_to_use) {
 					batch_queue_current = 0;
 				}
 				else {


### PR DESCRIPTION
Currently it will use all availible threads for processing. The main thread will still create the queue and take away cpu from the other threads. This will when creating the queue create 1 less thread so the main thread can use it.