### PR TITLE
WIP: merge-id

### DIFF
--- a/app/Index/Index.cpp
+++ b/app/Index/Index.cpp
@@ -325,7 +325,7 @@ int Index::uninitialize() {
   return 0;
 }
 
-int Index::add(index_combine_data &index_to_add) {
+int Index::add(index_combine_data &index_to_add, int merge_id) {
   std::error_code ec;
   if (!initialized || lock_status(false) <= 0) {
     Log::write(3, "Index: Can not add because index is not initialized or "
@@ -368,7 +368,7 @@ int Index::add(index_combine_data &index_to_add) {
                  "files will be deleted on startup.");
     }
   } else {
-    if (merge(index_to_add) == 1) {
+    if (merge(index_to_add, merge_id) == 1) {
       unlock(false); // unlock after done
       return 1;
     }

--- a/app/Index/Index_Merge.cpp
+++ b/app/Index/Index_Merge.cpp
@@ -518,7 +518,9 @@ void Index::insertion_to_transactions(
   to_insertions.clear();
 }
 
-int Index::merge(index_combine_data &index_to_add) {
+int Index::merge(index_combine_data &index_to_add, int merge_id) {
+  // index_to_add is a LocalIndex. merge id is the id for the whole merge
+  // operation and to refrence transaction file, mtime update file, etc..
   Log::write(1, "indexer: add: adding to existing index.");
   std::error_code ec;
   map();
@@ -968,8 +970,9 @@ int Index::merge(index_combine_data &index_to_add) {
   // transaction.list Backups are saved in indexpath / transaction /
   // backups / backupid.backup
 
-  std::filesystem::path transaction_path =
-      CONFIG_INDEX_PATH / "transaction" / "transaction.list";
+  std::filesystem::path transaction_path = CONFIG_INDEX_PATH / "transaction" /
+                                           "transaction-" /
+                                           std::to_string(merge_id) / ".list";
 
   if (write_transaction_file(transaction_path, move_transactions,
                              transactions) == 1) {

--- a/app/Index/Index_Merge.cpp
+++ b/app/Index/Index_Merge.cpp
@@ -518,36 +518,6 @@ void Index::insertion_to_transactions(
   to_insertions.clear();
 }
 
-void Index::write_to_transaction(std::vector<Transaction> &transactions,
-                                 mio::mmap_sink &mmap_transactions,
-                                 size_t &transaction_file_location) {
-  std::error_code ec;
-  for (size_t i = 0; i < transactions.size(); ++i) {
-    // copy the header first. Then check the operation type and then copy
-    // the content if needed.
-    std::memcpy(&mmap_transactions[transaction_file_location],
-                &transactions[i].header.bytes[0], 27);
-    transaction_file_location += 27;
-    if (transactions[i].header.operation_type != 2 &&
-        transactions[i].header.operation_type != 3) { // resize or backup
-      if (transactions[i].header.operation_type == 0) {
-        // For move operations content is 8 bytes long as a uint64_t to
-        // represent the byte shift. content length is used for end pos.
-        std::memcpy(&mmap_transactions[transaction_file_location],
-                    &transactions[i].content[0], 8);
-        transaction_file_location += 8;
-      } else {
-        std::memcpy(&mmap_transactions[transaction_file_location],
-                    &transactions[i].content[0],
-                    transactions[i].header.content_length);
-        transaction_file_location += transactions[i].header.content_length;
-      }
-    }
-  }
-  if (ec)
-    Log::error("Index: Write to Transaction Failed. Exiting");
-}
-
 int Index::merge(index_combine_data &index_to_add) {
   Log::write(1, "indexer: add: adding to existing index.");
   std::error_code ec;

--- a/app/Index/index.h
+++ b/app/Index/index.h
@@ -80,7 +80,7 @@ private:
   static void write_to_transaction(std::vector<Transaction> &transactions,
                                    mio::mmap_sink &mmap_transactions,
                                    size_t &transaction_file_location);
-  static int merge(index_combine_data &index_to_add);
+  static int merge(index_combine_data &index_to_add, int merge_id);
   static int execute_transactions();
   static std::vector<PATH_ID_TYPE> path_ids_from_word_id(uint64_t word_id);
   static void lock_update_sizes();

--- a/app/Index/index.h
+++ b/app/Index/index.h
@@ -95,7 +95,7 @@ public:
   static bool is_index_mapped();
   static int initialize();
   static int uninitialize();
-  static int add(index_combine_data &index_to_add);
+  static int add(index_combine_data &index_to_add, int merge_id);
   static std::vector<search_path_ids_return>
   search_word_list(std::vector<std::string> &search_words, bool exact_match,
                    int min_char_for_match);

--- a/app/LocalIndex/LocalIndex.cpp
+++ b/app/LocalIndex/LocalIndex.cpp
@@ -81,7 +81,7 @@ void LocalIndex::sort() {
   return;
 }
 
-void LocalIndex::add_to_disk() {
+void LocalIndex::add_to_disk(int merge_id) {
   if (paths_size == 0 || path_word_count_size == 0 || reversed_size == 0 ||
       words_size == 0)
     return; // do not try to add if we don't have anything to add.
@@ -96,7 +96,7 @@ void LocalIndex::add_to_disk() {
                                   words_size,
                                   reversed_size};
 
-  Index::add(index_to_add);
+  Index::add(index_to_add, merge_id);
   clear();
   return;
 }

--- a/app/LocalIndex/localindex.h
+++ b/app/LocalIndex/localindex.h
@@ -33,7 +33,7 @@ public:
   void add_words(std::unordered_set<std::string> &words_to_insert,
                  PATH_ID_TYPE path_id);
   void sort();
-  void add_to_disk();
+  void add_to_disk(int merge_id);
   void combine(LocalIndex &to_combine_index, const bool adding);
 
   friend void combine(LocalIndex &to_combine_index);


### PR DESCRIPTION
Use merge ids for each index. Rename transaction file to use number in filename. This will then be used to reliably update last indexed time later.

TODO:
- [ ] Handle multi merge merges
- [ ] Handle reading renamed transaction file
- [ ] Handle multiple transaction files
- [ ] Docs updates