### PR TITLE
io-separation and refactoring

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,53 @@
+---
+Language: Cpp
+BasedOnStyle: LLVM
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignOperands: false
+AlignTrailingComments: false
+AlwaysBreakTemplateDeclarations: Yes
+BraceWrapping:
+  AfterCaseLabel: true
+  AfterClass: true
+  AfterControlStatement: false
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: false
+  BeforeCatch: true
+  BeforeElse: true
+  BeforeLambdaBody: true
+  BeforeWhile: true
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBraces: Custom
+BreakConstructorInitializers: AfterColon
+BreakConstructorInitializersBeforeComma: false
+ColumnLimit: 120
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ContinuationIndentWidth: 2
+IncludeCategories:
+  - Regex: '^<.*'
+    Priority: 1
+  - Regex: '^".*'
+    Priority: 2
+  - Regex: '.*'
+    Priority: 3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseBlocks: true
+InsertNewlineAtEOF: true
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: All
+PointerAlignment: Left
+SpaceInEmptyParentheses: false
+SpacesInAngles: false
+SpacesInConditionalStatement: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+TabWidth: 2
+...

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ set(SOURCES
         app/Index/Index_Check.cpp
         #Disk IO
         app/Index/DiskIO/DiskIO.cpp
+        app/Index/DiskIO/DiskIO_Public_Getters.cpp
 
 
         # Indexer

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,8 @@ set(SOURCES
         app/Index/Index_Search.cpp
         app/Index/Index_Transaction.cpp
         app/Index/Index_Check.cpp
+        #Disk IO
+        app/Index/DiskIO/DiskIO.cpp
 
 
         # Indexer

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ set(SOURCES
 
         # Search
         app/Search/Search.cpp
+        app/Index/DiskIO/DiskIO_Words.cpp
 )
 
 set(HEADERS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ set(SOURCES
         app/Index/DiskIO/DiskIO_WordsF.cpp
         app/Index/DiskIO/DiskIO_Paths.cpp
         app/Index/DiskIO/DiskIO_PathsCount.cpp
+        app/Index/DiskIO/DiskIO_Move.cpp
 
         # Indexer
         app/Indexer/Indexer.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,9 @@ set(SOURCES
         app/Index/DiskIO/DiskIO_Public_Getters.cpp
         app/Index/DiskIO/DiskIO_Additional.cpp
         app/Index/DiskIO/DiskIO_Reversed.cpp
-
+        app/Index/DiskIO/DiskIO_Words.cpp
+        app/Index/DiskIO/DiskIO_WordsF.cpp
+        app/Index/DiskIO/DiskIO_Paths.cpp
 
         # Indexer
         app/Indexer/Indexer.cpp
@@ -60,7 +62,7 @@ set(SOURCES
 
         # Search
         app/Search/Search.cpp
-        app/Index/DiskIO/DiskIO_Words.cpp
+
 )
 
 set(HEADERS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ set(SOURCES
         app/Index/DiskIO/DiskIO_Words.cpp
         app/Index/DiskIO/DiskIO_WordsF.cpp
         app/Index/DiskIO/DiskIO_Paths.cpp
+        app/Index/DiskIO/DiskIO_PathsCount.cpp
 
         # Indexer
         app/Indexer/Indexer.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ set(SOURCES
         #Disk IO
         app/Index/DiskIO/DiskIO.cpp
         app/Index/DiskIO/DiskIO_Public_Getters.cpp
+        app/Index/DiskIO/DiskIO_Additional.cpp
 
 
         # Indexer

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ set(SOURCES
         app/Index/DiskIO/DiskIO.cpp
         app/Index/DiskIO/DiskIO_Public_Getters.cpp
         app/Index/DiskIO/DiskIO_Additional.cpp
+        app/Index/DiskIO/DiskIO_Reversed.cpp
 
 
         # Indexer

--- a/app/Helper/Helper.cpp
+++ b/app/Helper/Helper.cpp
@@ -1,45 +1,58 @@
 #include "helper.h"
+#include "../Logging/logging.h"
 #include <filesystem>
 #include <string>
 #include <unordered_map>
 
-int Helper::file_size(const std::filesystem::path &file_path) {
-  int size = -1;
+size_t Helper::file_size(const std::filesystem::path& file_path)
+{
+  size_t size = -1;
   std::error_code ec;
   size = std::filesystem::file_size(file_path, ec);
+  if (ec) {
+    Log::write(4, "Helper::file_size: error getting file size.");
+    return 0;
+  }
   return size;
 }
 
 // returns the extension of the file. Currently it will determine that by the
 // extension in the filename. It may be changed for a better dedection in the
 // future.
-std::string Helper::file_extension(const std::filesystem::path &path) {
+std::string Helper::file_extension(const std::filesystem::path& path)
+{
   return path.extension();
 }
 
-void Helper::convert_char(char &c) {
+void Helper::convert_char(char& c)
+{
   if (c >= 0 && c < 256) {
     c = conversion_table[static_cast<unsigned char>(c)];
-  } else {
+  }
+  else {
     auto it = special_chars.find(c);
     if (it != special_chars.end()) {
       c = it->second;
-    } else {
+    }
+    else {
       c = '!';
     }
   }
   return;
 }
 
-const std::array<char, 256> Helper::conversion_table = []() {
+const std::array<char, 256> Helper::conversion_table = []()
+{
   std::array<char, 256> table;
   for (int i = 0; i < 256; ++i) {
     char c = static_cast<char>(i);
     if (c >= 'a' && c <= 'z') {
       table[i] = c;
-    } else if (c >= 'A' && c <= 'Z') {
+    }
+    else if (c >= 'A' && c <= 'Z') {
       table[i] = c - 'A' + 'a';
-    } else {
+    }
+    else {
       table[i] = '!';
     }
   }
@@ -48,13 +61,14 @@ const std::array<char, 256> Helper::conversion_table = []() {
 
 // Initialize the special characters map
 const std::unordered_map<char, char> Helper::special_chars = {
-    {'ä', 'a'}, {'Ä', 'a'}, {'å', 'a'}, {'Å', 'a'}, {'à', 'a'}, {'À', 'a'},
-    {'á', 'a'}, {'Á', 'a'}, {'â', 'a'}, {'Â', 'a'}, {'ã', 'a'}, {'Ã', 'a'},
-    {'ö', 'o'}, {'Ö', 'o'}, {'ò', 'o'}, {'Ò', 'o'}, {'ó', 'o'}, {'Ó', 'o'},
-    {'ô', 'o'}, {'Ô', 'o'}, {'õ', 'o'}, {'Õ', 'o'}, {'é', 'e'}, {'É', 'e'},
-    {'è', 'e'}, {'È', 'e'}, {'ê', 'e'}, {'Ê', 'e'}, {'ë', 'e'}, {'Ë', 'e'},
-    {'ü', 'u'}, {'Ü', 'u'}, {'ù', 'u'}, {'Ù', 'u'}, {'ú', 'u'}, {'Ú', 'u'},
-    {'û', 'u'}, {'Û', 'u'}, {'ì', 'i'}, {'Ì', 'i'}, {'í', 'i'}, {'Í', 'i'},
-    {'î', 'i'}, {'Î', 'i'}, {'ï', 'i'}, {'Ï', 'i'}, {'ñ', 'n'}, {'Ñ', 'n'},
-    {'ý', 'y'}, {'Ý', 'y'}, {'ÿ', 'y'}, {'Ÿ', 'y'}, {'ç', 'c'}, {'Ç', 'c'},
-    {'ß', 's'}};
+  {'ä', 'a'}, {'Ä', 'a'}, {'å', 'a'}, {'Å', 'a'}, {'à', 'a'}, {'À', 'a'},
+  {'á', 'a'}, {'Á', 'a'}, {'â', 'a'}, {'Â', 'a'}, {'ã', 'a'}, {'Ã', 'a'},
+  {'ö', 'o'}, {'Ö', 'o'}, {'ò', 'o'}, {'Ò', 'o'}, {'ó', 'o'}, {'Ó', 'o'},
+  {'ô', 'o'}, {'Ô', 'o'}, {'õ', 'o'}, {'Õ', 'o'}, {'é', 'e'}, {'É', 'e'},
+  {'è', 'e'}, {'È', 'e'}, {'ê', 'e'}, {'Ê', 'e'}, {'ë', 'e'}, {'Ë', 'e'},
+  {'ü', 'u'}, {'Ü', 'u'}, {'ù', 'u'}, {'Ù', 'u'}, {'ú', 'u'}, {'Ú', 'u'},
+  {'û', 'u'}, {'Û', 'u'}, {'ì', 'i'}, {'Ì', 'i'}, {'í', 'i'}, {'Í', 'i'},
+  {'î', 'i'}, {'Î', 'i'}, {'ï', 'i'}, {'Ï', 'i'}, {'ñ', 'n'}, {'Ñ', 'n'},
+  {'ý', 'y'}, {'Ý', 'y'}, {'ÿ', 'y'}, {'Ÿ', 'y'}, {'ç', 'c'}, {'Ç', 'c'},
+  {'ß', 's'}
+};

--- a/app/Helper/Helper.cpp
+++ b/app/Helper/Helper.cpp
@@ -6,7 +6,7 @@
 
 size_t Helper::file_size(const std::filesystem::path& file_path)
 {
-  size_t size = -1;
+  size_t size = 0;
   std::error_code ec;
   size = std::filesystem::file_size(file_path, ec);
   if (ec) {

--- a/app/Helper/helper.h
+++ b/app/Helper/helper.h
@@ -12,15 +12,16 @@
 #include <vector>
 
 // Helper/Helper.cpp
-class Helper {
+class Helper
+{
 private:
   static const std::array<char, 256> conversion_table;
   static const std::unordered_map<char, char> special_chars;
 
 public:
-  static int file_size(const std::filesystem::path &file_path);
-  static std::string file_extension(const std::filesystem::path &path);
-  static void convert_char(char &c);
+  static size_t file_size(const std::filesystem::path& file_path);
+  static std::string file_extension(const std::filesystem::path& path);
+  static void convert_char(char& c);
 };
 
 #endif

--- a/app/Index/DiskIO/DiskIO.cpp
+++ b/app/Index/DiskIO/DiskIO.cpp
@@ -13,7 +13,7 @@ Index::DiskIO::DiskIO()
     , words_f_size(0)
     , reversed_size(0)
     , additional_size(0)
-    , additional_mapped(0)
+    , additional_mapped(false)
     , is_mapped(false)
     , is_locked(false)
 {

--- a/app/Index/DiskIO/DiskIO.cpp
+++ b/app/Index/DiskIO/DiskIO.cpp
@@ -91,37 +91,37 @@ bool Index::DiskIO::map(const std::filesystem::path& index_path)
 
   // paths.index
   if (!map_file(mmap_paths, paths_size, (index_path / "paths.index").string())) {
-    Log::write(4, "Index::DiskIO::map: mapping failed.");
+    Log::write(4, "Index::DiskIO::map: paths mapping failed.");
     unmap();
     return false;
   }
   // paths_count.index
-  if (!map_file(mmap_paths, paths_size, (index_path / "paths.index").string())) {
-    Log::write(4, "Index::DiskIO::map: mapping failed.");
+  if (!map_file(mmap_paths, paths_size, (index_path / "paths_count.index").string())) {
+    Log::write(4, "Index::DiskIO::map: paths_count mapping failed.");
     unmap();
     return false;
   }
   // words.index
-  if (!map_file(mmap_paths, paths_size, (index_path / "paths.index").string())) {
-    Log::write(4, "Index::DiskIO::map: mapping failed.");
+  if (!map_file(mmap_paths, paths_size, (index_path / "words.index").string())) {
+    Log::write(4, "Index::DiskIO::map: words mapping failed.");
     unmap();
     return false;
   }
   // words_f.index
-  if (!map_file(mmap_paths, paths_size, (index_path / "paths.index").string())) {
-    Log::write(4, "Index::DiskIO::map: mapping failed.");
+  if (!map_file(mmap_paths, paths_size, (index_path / "words_f.index").string())) {
+    Log::write(4, "Index::DiskIO::map: words_f mapping failed.");
     unmap();
     return false;
   }
   // reversed.index
-  if (!map_file(mmap_paths, paths_size, (index_path / "paths.index").string())) {
-    Log::write(4, "Index::DiskIO::map: mapping failed.");
+  if (!map_file(mmap_paths, paths_size, (index_path / "reversed.index").string())) {
+    Log::write(4, "Index::DiskIO::map: reversed mapping failed.");
     unmap();
     return false;
   }
   // additional.index
   // this one can fail: if there is no additional then it's size is 0.
-  if (!map_file(mmap_paths, paths_size, (index_path / "paths.index").string())) {
+  if (!map_file(mmap_paths, paths_size, (index_path / "additional.index").string())) {
     additional_mapped = false;
     Log::write(4, "Index::DiskIO::map: mapping failed for additional. This is allowed if it's size is 0.");
   }

--- a/app/Index/DiskIO/DiskIO.cpp
+++ b/app/Index/DiskIO/DiskIO.cpp
@@ -96,32 +96,32 @@ bool Index::DiskIO::map(const std::filesystem::path& index_path)
     return false;
   }
   // paths_count.index
-  if (!map_file(mmap_paths, paths_size, (index_path / "paths_count.index").string())) {
+  if (!map_file(mmap_paths_count, paths_count_size, (index_path / "paths_count.index").string())) {
     Log::write(4, "Index::DiskIO::map: paths_count mapping failed.");
     unmap();
     return false;
   }
   // words.index
-  if (!map_file(mmap_paths, paths_size, (index_path / "words.index").string())) {
+  if (!map_file(mmap_words, words_size, (index_path / "words.index").string())) {
     Log::write(4, "Index::DiskIO::map: words mapping failed.");
     unmap();
     return false;
   }
   // words_f.index
-  if (!map_file(mmap_paths, paths_size, (index_path / "words_f.index").string())) {
+  if (!map_file(mmap_words_f, words_f_size, (index_path / "words_f.index").string())) {
     Log::write(4, "Index::DiskIO::map: words_f mapping failed.");
     unmap();
     return false;
   }
   // reversed.index
-  if (!map_file(mmap_paths, paths_size, (index_path / "reversed.index").string())) {
+  if (!map_file(mmap_reversed, reversed_size, (index_path / "reversed.index").string())) {
     Log::write(4, "Index::DiskIO::map: reversed mapping failed.");
     unmap();
     return false;
   }
   // additional.index
   // this one can fail: if there is no additional then it's size is 0.
-  if (!map_file(mmap_paths, paths_size, (index_path / "additional.index").string())) {
+  if (!map_file(mmap_additional, additional_size, (index_path / "additional.index").string())) {
     additional_mapped = false;
     Log::write(4, "Index::DiskIO::map: mapping failed for additional. This is allowed if it's size is 0.");
   }

--- a/app/Index/DiskIO/DiskIO.cpp
+++ b/app/Index/DiskIO/DiskIO.cpp
@@ -60,6 +60,10 @@ bool Index::DiskIO::map(const std::filesystem::path& index_path)
     Log::write(4, "Index::DiskIO::map: could not map. index path invalid.");
     return false;
   }
+  if (ec) {
+    Log::write(4, "Index::DiskIO::map: could not map. index path validation threw an error");
+    return false;
+  }
 
   // paths.index
   if (!map_file(mmap_paths, paths_size, (index_path / "paths.index").string())) {
@@ -102,4 +106,35 @@ bool Index::DiskIO::map(const std::filesystem::path& index_path)
   }
 
   is_mapped = true;
+  Log::write(1, "Index::DiskIO::map: mapped files successfully.");
+
+  return true;
+}
+
+bool Index::DiskIO::unmap()
+{
+  if (mmap_paths.is_mapped()) {
+    mmap_paths.unmap();
+  }
+  if (mmap_paths_count.is_mapped()) {
+    mmap_paths_count.unmap();
+  }
+  if (mmap_words.is_mapped()) {
+    mmap_words.unmap();
+  }
+  if (mmap_words_f.is_mapped()) {
+    mmap_words_f.unmap();
+  }
+  if (mmap_reversed.is_mapped()) {
+    mmap_reversed.unmap();
+  }
+  if (mmap_additional.is_mapped()) {
+    mmap_additional.unmap();
+  }
+
+  additional_mapped = false;
+  is_mapped = false;
+  Log::write(1, "Index::DiskIO::unmap: unmapped files successfully.");
+
+  return true;
 }

--- a/app/Index/DiskIO/DiskIO.cpp
+++ b/app/Index/DiskIO/DiskIO.cpp
@@ -6,20 +6,10 @@
 #include <fstream>
 #include <string>
 
-Index::DiskIO::DiskIO()
-  : paths_size(0)
-    , paths_count_size(0)
-    , words_size(0)
-    , words_f_size(0)
-    , reversed_size(0)
-    , additional_size(0)
-    , additional_mapped(false)
-    , is_mapped(false)
-    , is_locked(false)
-{
-}
 
-bool Index::DiskIO::sync_file(mio::mmap_sink& target_mmap)
+Index::DiskIO::DiskIO() = default;
+
+bool Index::DiskIO::sync_file(mio::mmap_sink& target_mmap) const
 {
   std::error_code ec;
   target_mmap.sync(ec);

--- a/app/Index/DiskIO/DiskIO.cpp
+++ b/app/Index/DiskIO/DiskIO.cpp
@@ -1,0 +1,105 @@
+#include "../index.h"
+#include "../../Helper/helper.h"
+#include "../../Logging/logging.h"
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+Index::DiskIO::DiskIO()
+  : paths_size(0)
+    , paths_count_size(0)
+    , words_size(0)
+    , words_f_size(0)
+    , reversed_size(0)
+    , additional_size(0)
+    , additional_mapped(0)
+    , is_mapped(false)
+    , is_locked(false)
+{
+}
+
+bool Index::DiskIO::map_file(mio::mmap_sink& target_mmap, size_t& target_size, const std::string& source_path)
+{
+  std::error_code ec;
+  if (!std::filesystem::exists(source_path, ec)) {
+    Log::write(4, "Index::DiskIO::map_file: could not map. index path invalid.");
+    return false;
+  }
+  if (ec) {
+    Log::write(4, "Index::DiskIO::map_file: could not map. validating path failed.");
+    return false;
+  }
+  size_t temp_size = Helper::file_size(source_path);
+  if (temp_size == 0) {
+    Log::write(4, "Index::DiskIO::map_file: could not map. file size is 0");
+    return false;
+  }
+  if (!target_mmap.is_mapped()) {
+    target_mmap =
+      mio::make_mmap_sink(source_path, 0,
+                          mio::map_entire_file, ec);
+    if (ec) {
+      Log::write(4, "Index::DiskIO::map_file: could not map. mapping failed");
+      target_size = 0;
+      return false;
+    }
+  }
+  else {
+    Log::write(1, "Index::DiskIO::map_file: file already mapped.");
+  }
+  target_size = temp_size;
+  Log::write(1, "Index::DiskIO::map_file: file successfully mapped.");
+  return true;
+}
+
+bool Index::DiskIO::map(const std::filesystem::path& index_path)
+{
+  std::error_code ec;
+  if (!std::filesystem::exists(index_path, ec)) {
+    Log::write(4, "Index::DiskIO::map: could not map. index path invalid.");
+    return false;
+  }
+
+  // paths.index
+  if (!map_file(mmap_paths, paths_size, (index_path / "paths.index").string())) {
+    Log::write(4, "Index::DiskIO::map: mapping failed.");
+    unmap();
+    return false;
+  }
+  // paths_count.index
+  if (!map_file(mmap_paths, paths_size, (index_path / "paths.index").string())) {
+    Log::write(4, "Index::DiskIO::map: mapping failed.");
+    unmap();
+    return false;
+  }
+  // words.index
+  if (!map_file(mmap_paths, paths_size, (index_path / "paths.index").string())) {
+    Log::write(4, "Index::DiskIO::map: mapping failed.");
+    unmap();
+    return false;
+  }
+  // words_f.index
+  if (!map_file(mmap_paths, paths_size, (index_path / "paths.index").string())) {
+    Log::write(4, "Index::DiskIO::map: mapping failed.");
+    unmap();
+    return false;
+  }
+  // reversed.index
+  if (!map_file(mmap_paths, paths_size, (index_path / "paths.index").string())) {
+    Log::write(4, "Index::DiskIO::map: mapping failed.");
+    unmap();
+    return false;
+  }
+  // additional.index
+  // this one can fail: if there is no additional then it's size is 0.
+  if (!map_file(mmap_paths, paths_size, (index_path / "paths.index").string())) {
+    additional_mapped = false;
+    Log::write(4, "Index::DiskIO::map: mapping failed for additional. This is allowed if it's size is 0.");
+  }
+  else {
+    additional_mapped = true;
+  }
+
+  is_mapped = true;
+}

--- a/app/Index/DiskIO/DiskIO.cpp
+++ b/app/Index/DiskIO/DiskIO.cpp
@@ -138,3 +138,26 @@ bool Index::DiskIO::unmap()
 
   return true;
 }
+
+bool Index::DiskIO::sync_file(mio::mmap_sink& target_mmap)
+{
+  std::error_code ec;
+  target_mmap.sync(ec);
+  if (ec) {
+    Log::write(4, "Index::DiskIO::sync_file: syncing failed.");
+    return false;
+  }
+  return true;
+}
+
+bool Index::DiskIO::sync_all()
+{
+  // Because sync may be called anytime, we will not check if the operation failed.
+  sync_file(mmap_paths);
+  sync_file(mmap_paths_count);
+  sync_file(mmap_words);
+  sync_file(mmap_words_f);
+  sync_file(mmap_reversed);
+  sync_file(mmap_additional);
+  return true;
+}

--- a/app/Index/DiskIO/DiskIO.cpp
+++ b/app/Index/DiskIO/DiskIO.cpp
@@ -32,13 +32,30 @@ bool Index::DiskIO::sync_file(mio::mmap_sink& target_mmap)
 
 bool Index::DiskIO::sync_all()
 {
-  // Because sync may be called anytime, we will not check if the operation failed.
-  sync_file(mmap_paths);
-  sync_file(mmap_paths_count);
-  sync_file(mmap_words);
-  sync_file(mmap_words_f);
-  sync_file(mmap_reversed);
-  sync_file(mmap_additional);
+  if (!sync_file(mmap_paths)) {
+    Log::write(4, "Index::DiskIO::sync_all: syncing failed for one file.");
+    return false;
+  }
+  if (!sync_file(mmap_paths_count)) {
+    Log::write(4, "Index::DiskIO::sync_all: syncing failed for one file.");
+    return false;
+  }
+  if (!sync_file(mmap_words)) {
+    Log::write(4, "Index::DiskIO::sync_all: syncing failed for one file.");
+    return false;
+  }
+  if (!sync_file(mmap_words_f)) {
+    Log::write(4, "Index::DiskIO::sync_all: syncing failed for one file.");
+    return false;
+  }
+  if (!sync_file(mmap_reversed)) {
+    Log::write(4, "Index::DiskIO::sync_all: syncing failed for one file.");
+    return false;
+  }
+  if (!sync_file(mmap_additional)) {
+    Log::write(4, "Index::DiskIO::sync_all: syncing failed for one file.");
+    return false;
+  }
   return true;
 }
 

--- a/app/Index/DiskIO/DiskIO_Additional.cpp
+++ b/app/Index/DiskIO/DiskIO_Additional.cpp
@@ -1,15 +1,26 @@
 #include "../index.h"
+#include "../../Logging/logging.h"
 #include <filesystem>
 #include <fstream>
 
 AdditionalBlock* Index::DiskIO::get_additional_pointer(const ADDITIONAL_ID_TYPE id)
 {
+#ifndef NDEBUG
+  if (additional_size < id * ADDITIONAL_ENTRY_SIZE) {
+    Log::error("Index::DiskIO::get_additional_pointer: out of bounds access denied.");
+  }
+#endif
   return reinterpret_cast<AdditionalBlock*>(
     &mmap_additional[(id - 1) * ADDITIONAL_ENTRY_SIZE]);
 }
 
 void Index::DiskIO::set_additional(const AdditionalBlock& additional_block, size_t additional_id)
 {
+#ifndef NDEBUG
+  if (additional_size < additional_id * ADDITIONAL_ENTRY_SIZE) {
+    Log::error("Index::DiskIO::get_additional_pointer: out of bounds access denied.");
+  }
+#endif
   *reinterpret_cast<AdditionalBlock*>(&mmap_additional[(additional_id - 1) * ADDITIONAL_ENTRY_SIZE]) =
     additional_block;
 }

--- a/app/Index/DiskIO/DiskIO_Additional.cpp
+++ b/app/Index/DiskIO/DiskIO_Additional.cpp
@@ -1,0 +1,13 @@
+#include "../index.h"
+#include "../../Helper/helper.h"
+#include "../../Logging/logging.h"
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+AdditionalBlock* Index::DiskIO::get_additional_pointer(const ADDITIONAL_ID_TYPE id)
+{
+  return reinterpret_cast<AdditionalBlock*>(
+    &mmap_additional[(id - 1) * ADDITIONAL_ENTRY_SIZE]);
+}

--- a/app/Index/DiskIO/DiskIO_Additional.cpp
+++ b/app/Index/DiskIO/DiskIO_Additional.cpp
@@ -1,10 +1,6 @@
 #include "../index.h"
-#include "../../Helper/helper.h"
-#include "../../Logging/logging.h"
-#include <cstring>
 #include <filesystem>
 #include <fstream>
-#include <string>
 
 AdditionalBlock* Index::DiskIO::get_additional_pointer(const ADDITIONAL_ID_TYPE id)
 {
@@ -14,6 +10,6 @@ AdditionalBlock* Index::DiskIO::get_additional_pointer(const ADDITIONAL_ID_TYPE 
 
 void Index::DiskIO::set_additional(const AdditionalBlock& additional_block, size_t additional_id)
 {
-  *reinterpret_cast<AdditionalBlock*>(&mmap_paths_count[(additional_id - 1) * ADDITIONAL_ENTRY_SIZE]) =
+  *reinterpret_cast<AdditionalBlock*>(&mmap_additional[(additional_id - 1) * ADDITIONAL_ENTRY_SIZE]) =
     additional_block;
 }

--- a/app/Index/DiskIO/DiskIO_Additional.cpp
+++ b/app/Index/DiskIO/DiskIO_Additional.cpp
@@ -11,3 +11,9 @@ AdditionalBlock* Index::DiskIO::get_additional_pointer(const ADDITIONAL_ID_TYPE 
   return reinterpret_cast<AdditionalBlock*>(
     &mmap_additional[(id - 1) * ADDITIONAL_ENTRY_SIZE]);
 }
+
+void Index::DiskIO::set_additional(const AdditionalBlock& additional_block, size_t additional_id)
+{
+  *reinterpret_cast<AdditionalBlock*>(&mmap_paths_count[(additional_id - 1) * ADDITIONAL_ENTRY_SIZE]) =
+    additional_block;
+}

--- a/app/Index/DiskIO/DiskIO_Move.cpp
+++ b/app/Index/DiskIO/DiskIO_Move.cpp
@@ -1,0 +1,54 @@
+#include "../index.h"
+#include "../../Helper/helper.h"
+#include "../../Logging/logging.h"
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include "CliParser/cliparser.h"
+#include "CliParser/cliparser.h"
+// index types:
+// paths = 0, words = 1, words_f = 2, reversed = 3,
+// additional = 4, paths_count = 5
+mio::mmap_sink* Index::DiskIO::get_target_mmap(uint8_t target_index)
+{
+  switch (target_index) {
+  case 1:
+    return &mmap_words;
+    break;
+  case 2:
+    return &mmap_words_f;
+    break;
+  case 3:
+    return &mmap_reversed;
+    break;
+  case 4:
+    return &mmap_additional;
+    break;
+  case 5:
+    return &mmap_paths_count;
+  default:
+    return &mmap_paths;
+    break;
+  }
+}
+
+void Index::DiskIO::copy_from_index(uint8_t source_index, mio::mmap_sink& target, size_t target_pos, size_t source_pos,
+                                    size_t length)
+{
+  std::memcpy(&target[target_pos], &(*get_target_mmap(source_index))[source_pos], length);
+}
+
+
+void Index::DiskIO::copy_to_index(uint8_t target_index, mio::mmap_sink& source, size_t target_pos, size_t source_pos,
+                                  size_t length)
+{
+  std::memcpy(&(*get_target_mmap(target_index))[target_pos], &source[source_pos], length);
+}
+
+void Index::DiskIO::shift_data(uint8_t target_index, size_t target_pos, size_t source_pos,
+                               size_t length)
+{
+  std::memmove(&(*get_target_mmap(target_index))[target_pos], &(*get_target_mmap(target_index))[source_pos], length);
+}

--- a/app/Index/DiskIO/DiskIO_Move.cpp
+++ b/app/Index/DiskIO/DiskIO_Move.cpp
@@ -1,4 +1,5 @@
 #include "../index.h"
+#include "../../Logging/logging.h"
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -24,9 +25,32 @@ mio::mmap_sink* Index::DiskIO::get_target_mmap(uint8_t target_index)
   }
 }
 
+size_t Index::DiskIO::get_target_size(const uint8_t target_index) const
+{
+  switch (target_index) {
+  case 1:
+    return words_size;
+  case 2:
+    return words_f_size;
+  case 3:
+    return reversed_size;
+  case 4:
+    return additional_size;
+  case 5:
+    return paths_count_size;
+  default:
+    return paths_size;
+  }
+}
+
 void Index::DiskIO::copy_from_index(uint8_t source_index, mio::mmap_sink& target, size_t target_pos, size_t source_pos,
                                     size_t length)
 {
+#ifndef NDEBUG
+  if (get_target_size(source_index) < source_pos + length) {
+    Log::error("Index::DiskIO::copy_from_index: (source mmap) out of bounds access denied.");
+  }
+#endif
   std::memcpy(&target[target_pos], &(*get_target_mmap(source_index))[source_pos], length);
 }
 
@@ -34,11 +58,21 @@ void Index::DiskIO::copy_from_index(uint8_t source_index, mio::mmap_sink& target
 void Index::DiskIO::copy_to_index(uint8_t target_index, mio::mmap_sink& source, size_t target_pos, size_t source_pos,
                                   size_t length)
 {
+#ifndef NDEBUG
+  if (get_target_size(target_index) < target_pos + length) {
+    Log::error("Index::DiskIO::copy_to_index: (target mmap) out of bounds access denied.");
+  }
+#endif
   std::memcpy(&(*get_target_mmap(target_index))[target_pos], &source[source_pos], length);
 }
 
 void Index::DiskIO::shift_data(uint8_t target_index, size_t target_pos, size_t source_pos,
                                size_t length)
 {
+#ifndef NDEBUG
+  if (get_target_size(target_index) < target_pos + length) {
+    Log::error("Index::DiskIO::shift_data: (mmap) out of bounds access denied.");
+  }
+#endif
   std::memmove(&(*get_target_mmap(target_index))[target_pos], &(*get_target_mmap(target_index))[source_pos], length);
 }

--- a/app/Index/DiskIO/DiskIO_Move.cpp
+++ b/app/Index/DiskIO/DiskIO_Move.cpp
@@ -1,13 +1,8 @@
 #include "../index.h"
-#include "../../Helper/helper.h"
-#include "../../Logging/logging.h"
 #include <cstring>
 #include <filesystem>
 #include <fstream>
-#include <string>
 
-#include "CliParser/cliparser.h"
-#include "CliParser/cliparser.h"
 // index types:
 // paths = 0, words = 1, words_f = 2, reversed = 3,
 // additional = 4, paths_count = 5

--- a/app/Index/DiskIO/DiskIO_Move.cpp
+++ b/app/Index/DiskIO/DiskIO_Move.cpp
@@ -16,21 +16,16 @@ mio::mmap_sink* Index::DiskIO::get_target_mmap(uint8_t target_index)
   switch (target_index) {
   case 1:
     return &mmap_words;
-    break;
   case 2:
     return &mmap_words_f;
-    break;
   case 3:
     return &mmap_reversed;
-    break;
   case 4:
     return &mmap_additional;
-    break;
   case 5:
     return &mmap_paths_count;
   default:
     return &mmap_paths;
-    break;
   }
 }
 

--- a/app/Index/DiskIO/DiskIO_Paths.cpp
+++ b/app/Index/DiskIO/DiskIO_Paths.cpp
@@ -1,6 +1,4 @@
 #include "../index.h"
-#include "../../Helper/helper.h"
-#include "../../Logging/logging.h"
 #include <cstring>
 #include <filesystem>
 #include <fstream>

--- a/app/Index/DiskIO/DiskIO_Paths.cpp
+++ b/app/Index/DiskIO/DiskIO_Paths.cpp
@@ -1,0 +1,18 @@
+#include "../index.h"
+#include "../../Helper/helper.h"
+#include "../../Logging/logging.h"
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+uint16_t Index::DiskIO::get_path_separator(const size_t start_pos) const
+{
+  return *reinterpret_cast<const uint16_t*>(&mmap_paths[start_pos]);
+}
+
+// Start pos is the pos of the first path byte and not the path separator.
+std::string Index::DiskIO::get_path(const size_t start_pos, const uint16_t length) const
+{
+  return std::string(&mmap_paths[start_pos], length);
+}

--- a/app/Index/DiskIO/DiskIO_Paths.cpp
+++ b/app/Index/DiskIO/DiskIO_Paths.cpp
@@ -24,5 +24,5 @@ std::string Index::DiskIO::get_path(const size_t start_pos, const uint16_t lengt
 
 void Index::DiskIO::set_path(const size_t start_pos, const std::string& path, const uint16_t length)
 {
-  std::memcpy(&mmap_paths[start_pos], path.data(), length);
+  std::memcpy(&mmap_paths[start_pos], &path[0], length);
 }

--- a/app/Index/DiskIO/DiskIO_Paths.cpp
+++ b/app/Index/DiskIO/DiskIO_Paths.cpp
@@ -11,8 +11,18 @@ uint16_t Index::DiskIO::get_path_separator(const size_t start_pos) const
   return *reinterpret_cast<const uint16_t*>(&mmap_paths[start_pos]);
 }
 
+void Index::DiskIO::set_path_separator(const size_t start_pos, const uint16_t separator)
+{
+  *reinterpret_cast<uint16_t*>(&mmap_paths[start_pos]) = separator;
+}
+
 // Start pos is the pos of the first path byte and not the path separator.
 std::string Index::DiskIO::get_path(const size_t start_pos, const uint16_t length) const
 {
   return std::string(&mmap_paths[start_pos], length);
+}
+
+void Index::DiskIO::set_path(const size_t start_pos, const std::string& path, const uint16_t length)
+{
+  std::memcpy(&mmap_paths[start_pos], path.data(), length);
 }

--- a/app/Index/DiskIO/DiskIO_Paths.cpp
+++ b/app/Index/DiskIO/DiskIO_Paths.cpp
@@ -8,12 +8,14 @@
 
 uint16_t Index::DiskIO::get_path_separator(const size_t start_pos) const
 {
-  return *reinterpret_cast<const uint16_t*>(&mmap_paths[start_pos]);
+  uint16_t separator;
+  std::memcpy(&separator, &mmap_paths[start_pos], sizeof(uint16_t));
+  return separator;
 }
 
 void Index::DiskIO::set_path_separator(const size_t start_pos, const uint16_t separator)
 {
-  *reinterpret_cast<uint16_t*>(&mmap_paths[start_pos]) = separator;
+  std::memcpy(&mmap_paths[start_pos], &separator, sizeof(uint16_t));
 }
 
 // Start pos is the pos of the first path byte and not the path separator.

--- a/app/Index/DiskIO/DiskIO_Paths.cpp
+++ b/app/Index/DiskIO/DiskIO_Paths.cpp
@@ -1,4 +1,5 @@
 #include "../index.h"
+#include "../../Logging/logging.h"
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -6,6 +7,11 @@
 
 uint16_t Index::DiskIO::get_path_separator(const size_t start_pos) const
 {
+#ifndef NDEBUG
+  if (paths_size < start_pos + 2) {
+    Log::error("Index::DiskIO::get_path_separator: out of bounds access denied.");
+  }
+#endif
   uint16_t separator;
   std::memcpy(&separator, &mmap_paths[start_pos], sizeof(uint16_t));
   return separator;
@@ -13,16 +19,31 @@ uint16_t Index::DiskIO::get_path_separator(const size_t start_pos) const
 
 void Index::DiskIO::set_path_separator(const size_t start_pos, const uint16_t separator)
 {
+#ifndef NDEBUG
+  if (paths_size < start_pos + 2) {
+    Log::error("Index::DiskIO::set_path_separator: out of bounds access denied.");
+  }
+#endif
   std::memcpy(&mmap_paths[start_pos], &separator, sizeof(uint16_t));
 }
 
 // Start pos is the pos of the first path byte and not the path separator.
 std::string Index::DiskIO::get_path(const size_t start_pos, const uint16_t length) const
 {
+#ifndef NDEBUG
+  if (paths_size < start_pos + length) {
+    Log::error("Index::DiskIO::get_path: out of bounds access denied.");
+  }
+#endif
   return std::string(&mmap_paths[start_pos], length);
 }
 
 void Index::DiskIO::set_path(const size_t start_pos, const std::string& path, const uint16_t length)
 {
+#ifndef NDEBUG
+  if (paths_size < start_pos + length) {
+    Log::error("Index::DiskIO::set_path: out of bounds access denied.");
+  }
+#endif
   std::memcpy(&mmap_paths[start_pos], &path[0], length);
 }

--- a/app/Index/DiskIO/DiskIO_PathsCount.cpp
+++ b/app/Index/DiskIO/DiskIO_PathsCount.cpp
@@ -1,0 +1,12 @@
+#include "../index.h"
+#include "../../Helper/helper.h"
+#include "../../Logging/logging.h"
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+uint32_t Index::DiskIO::get_path_count(const size_t path_id) const
+{
+  return *reinterpret_cast<const uint32_t*>(&mmap_paths_count[(path_id - 1) * 4]);
+}

--- a/app/Index/DiskIO/DiskIO_PathsCount.cpp
+++ b/app/Index/DiskIO/DiskIO_PathsCount.cpp
@@ -1,10 +1,6 @@
 #include "../index.h"
-#include "../../Helper/helper.h"
-#include "../../Logging/logging.h"
-#include <cstring>
 #include <filesystem>
 #include <fstream>
-#include <string>
 
 uint32_t Index::DiskIO::get_path_count(const size_t path_id) const
 {

--- a/app/Index/DiskIO/DiskIO_PathsCount.cpp
+++ b/app/Index/DiskIO/DiskIO_PathsCount.cpp
@@ -1,13 +1,24 @@
 #include "../index.h"
+#include "../../Logging/logging.h"
 #include <filesystem>
 #include <fstream>
 
 uint32_t Index::DiskIO::get_path_count(const size_t path_id) const
 {
+#ifndef NDEBUG
+  if (paths_count_size < path_id * 4) {
+    Log::error("Index::DiskIO::get_path_count: out of bounds access denied.");
+  }
+#endif
   return *reinterpret_cast<const uint32_t*>(&mmap_paths_count[(path_id - 1) * 4]);
 }
 
 void Index::DiskIO::set_path_count(const size_t path_id, const uint32_t path_count)
 {
+#ifndef NDEBUG
+  if (paths_count_size < path_id * 4) {
+    Log::error("Index::DiskIO::set_path_count: out of bounds access denied.");
+  }
+#endif
   *reinterpret_cast<uint32_t*>(&mmap_paths_count[(path_id - 1) * 4]) = path_count;
 }

--- a/app/Index/DiskIO/DiskIO_PathsCount.cpp
+++ b/app/Index/DiskIO/DiskIO_PathsCount.cpp
@@ -10,3 +10,8 @@ uint32_t Index::DiskIO::get_path_count(const size_t path_id) const
 {
   return *reinterpret_cast<const uint32_t*>(&mmap_paths_count[(path_id - 1) * 4]);
 }
+
+void Index::DiskIO::set_path_count(const size_t path_id, const uint32_t path_count)
+{
+  *reinterpret_cast<uint32_t*>(&mmap_paths_count[(path_id - 1) * 4]) = path_count;
+}

--- a/app/Index/DiskIO/DiskIO_Public_Getters.cpp
+++ b/app/Index/DiskIO/DiskIO_Public_Getters.cpp
@@ -1,10 +1,5 @@
 #include "../index.h"
-#include "../../Helper/helper.h"
-#include "../../Logging/logging.h"
-#include <cstring>
-#include <filesystem>
 #include <fstream>
-#include <string>
 
 
 size_t Index::DiskIO::get_paths_size() const

--- a/app/Index/DiskIO/DiskIO_Public_Getters.cpp
+++ b/app/Index/DiskIO/DiskIO_Public_Getters.cpp
@@ -1,0 +1,48 @@
+#include "../index.h"
+#include "../../Helper/helper.h"
+#include "../../Logging/logging.h"
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+
+size_t Index::DiskIO::get_paths_size() const
+{
+  return paths_size;
+}
+
+size_t Index::DiskIO::get_paths_count_size() const
+{
+  return paths_count_size;
+}
+
+size_t Index::DiskIO::get_words_size() const
+{
+  return words_size;
+}
+
+size_t Index::DiskIO::get_words_f_size() const
+{
+  return words_f_size;
+}
+
+size_t Index::DiskIO::get_reversed_size() const
+{
+  return reversed_size;
+}
+
+size_t Index::DiskIO::get_additional_size() const
+{
+  return additional_size;
+}
+
+bool Index::DiskIO::get_mapped() const
+{
+  return is_mapped;
+}
+
+bool Index::DiskIO::get_locked() const
+{
+  return is_locked;
+}

--- a/app/Index/DiskIO/DiskIO_Reversed.cpp
+++ b/app/Index/DiskIO/DiskIO_Reversed.cpp
@@ -1,18 +1,24 @@
 #include "../index.h"
-#include "../../Helper/helper.h"
 #include "../../Logging/logging.h"
-#include <cstring>
-#include <filesystem>
 #include <fstream>
-#include <string>
 
 ReversedBlock* Index::DiskIO::get_reversed_pointer(const size_t id)
 {
+#ifndef NDEBUG
+  if (reversed_size < id * REVERSED_ENTRY_SIZE) {
+    Log::error("Index::DiskIO::get_reversed_pointer: out of bounds access denied.");
+  }
+#endif
   return reinterpret_cast<ReversedBlock*>(
     &mmap_reversed[id * REVERSED_ENTRY_SIZE]);
 }
 
 void Index::DiskIO::set_reversed(const ReversedBlock& reversed_block, size_t word_id)
 {
+#ifndef NDEBUG
+  if (reversed_size < word_id * REVERSED_ENTRY_SIZE) {
+    Log::error("Index::DiskIO::set_reversed_pointer: out of bounds access denied.");
+  }
+#endif
   *reinterpret_cast<ReversedBlock*>(&mmap_reversed[word_id * REVERSED_ENTRY_SIZE]) = reversed_block;
 }

--- a/app/Index/DiskIO/DiskIO_Reversed.cpp
+++ b/app/Index/DiskIO/DiskIO_Reversed.cpp
@@ -14,5 +14,5 @@ ReversedBlock* Index::DiskIO::get_reversed_pointer(const size_t id)
 
 void Index::DiskIO::set_reversed(const ReversedBlock& reversed_block, size_t word_id)
 {
-  *reinterpret_cast<ReversedBlock*>(&mmap_paths_count[word_id * REVERSED_ENTRY_SIZE]) = reversed_block;
+  *reinterpret_cast<ReversedBlock*>(&mmap_reversed[word_id * REVERSED_ENTRY_SIZE]) = reversed_block;
 }

--- a/app/Index/DiskIO/DiskIO_Reversed.cpp
+++ b/app/Index/DiskIO/DiskIO_Reversed.cpp
@@ -11,3 +11,8 @@ ReversedBlock* Index::DiskIO::get_reversed_pointer(const size_t id)
   return reinterpret_cast<ReversedBlock*>(
     &mmap_reversed[id * REVERSED_ENTRY_SIZE]);
 }
+
+void Index::DiskIO::set_reversed(const ReversedBlock& reversed_block, size_t word_id)
+{
+  *reinterpret_cast<ReversedBlock*>(&mmap_paths_count[word_id * REVERSED_ENTRY_SIZE]) = reversed_block;
+}

--- a/app/Index/DiskIO/DiskIO_Reversed.cpp
+++ b/app/Index/DiskIO/DiskIO_Reversed.cpp
@@ -1,0 +1,13 @@
+#include "../index.h"
+#include "../../Helper/helper.h"
+#include "../../Logging/logging.h"
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+ReversedBlock* Index::DiskIO::get_reversed_pointer(const size_t id)
+{
+  return reinterpret_cast<ReversedBlock*>(
+    &mmap_reversed[id * REVERSED_ENTRY_SIZE]);
+}

--- a/app/Index/DiskIO/DiskIO_Words.cpp
+++ b/app/Index/DiskIO/DiskIO_Words.cpp
@@ -1,6 +1,4 @@
 #include "../index.h"
-#include "../../Helper/helper.h"
-#include "../../Logging/logging.h"
 #include <cstring>
 #include <filesystem>
 #include <fstream>

--- a/app/Index/DiskIO/DiskIO_Words.cpp
+++ b/app/Index/DiskIO/DiskIO_Words.cpp
@@ -16,7 +16,7 @@ void Index::DiskIO::set_word_separator(const size_t start_pos, const WORD_SEPARA
   std::memcpy(&mmap_words[start_pos], &separator, sizeof(WORD_SEPARATOR_TYPE));
 }
 
-char Index::DiskIO::get_char_of_word(size_t word_start_pos, int char_pos) const
+char Index::DiskIO::get_char_of_word(size_t word_start_pos, uint16_t char_pos) const
 {
   return mmap_words[word_start_pos +
     WORD_SEPARATOR_SIZE + char_pos];

--- a/app/Index/DiskIO/DiskIO_Words.cpp
+++ b/app/Index/DiskIO/DiskIO_Words.cpp
@@ -11,8 +11,18 @@ WORD_SEPARATOR_TYPE Index::DiskIO::get_word_separator(const size_t start_pos) co
   return *reinterpret_cast<const WORD_SEPARATOR_TYPE*>(&mmap_words[start_pos]);
 }
 
+void Index::DiskIO::set_word_separator(const size_t start_pos, const WORD_SEPARATOR_TYPE separator)
+{
+  *reinterpret_cast<WORD_SEPARATOR_TYPE*>(&mmap_words[start_pos]) = separator;
+}
+
 char Index::DiskIO::get_char_of_word(size_t word_start_pos, int char_pos) const
 {
   return mmap_words[word_start_pos +
     WORD_SEPARATOR_SIZE + char_pos];
+}
+
+void Index::DiskIO::set_word(const size_t start_pos, const std::string& word, const uint16_t length)
+{
+  std::memcpy(&mmap_words[start_pos], word.data(), length);
 }

--- a/app/Index/DiskIO/DiskIO_Words.cpp
+++ b/app/Index/DiskIO/DiskIO_Words.cpp
@@ -1,0 +1,18 @@
+#include "../index.h"
+#include "../../Helper/helper.h"
+#include "../../Logging/logging.h"
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+WORD_SEPARATOR_TYPE Index::DiskIO::get_word_separator(const size_t start_pos) const
+{
+  return *reinterpret_cast<const WORD_SEPARATOR_TYPE*>(&mmap_words[start_pos]);
+}
+
+char Index::DiskIO::get_char_of_word(size_t word_start_pos, int char_pos) const
+{
+  return mmap_words[word_start_pos +
+    WORD_SEPARATOR_SIZE + char_pos];
+}

--- a/app/Index/DiskIO/DiskIO_Words.cpp
+++ b/app/Index/DiskIO/DiskIO_Words.cpp
@@ -8,12 +8,14 @@
 
 WORD_SEPARATOR_TYPE Index::DiskIO::get_word_separator(const size_t start_pos) const
 {
-  return *reinterpret_cast<const WORD_SEPARATOR_TYPE*>(&mmap_words[start_pos]);
+  WORD_SEPARATOR_TYPE separator;
+  std::memcpy(&separator, &mmap_words[start_pos], sizeof(WORD_SEPARATOR_TYPE));
+  return separator;
 }
 
 void Index::DiskIO::set_word_separator(const size_t start_pos, const WORD_SEPARATOR_TYPE separator)
 {
-  *reinterpret_cast<WORD_SEPARATOR_TYPE*>(&mmap_words[start_pos]) = separator;
+  std::memcpy(&mmap_words[start_pos], &separator, sizeof(WORD_SEPARATOR_TYPE));
 }
 
 char Index::DiskIO::get_char_of_word(size_t word_start_pos, int char_pos) const

--- a/app/Index/DiskIO/DiskIO_Words.cpp
+++ b/app/Index/DiskIO/DiskIO_Words.cpp
@@ -1,4 +1,5 @@
 #include "../index.h"
+#include "../../Logging/logging.h"
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -6,23 +7,50 @@
 
 WORD_SEPARATOR_TYPE Index::DiskIO::get_word_separator(const size_t start_pos) const
 {
+#ifndef NDEBUG
+  if (words_size < start_pos + WORD_SEPARATOR_SIZE) {
+    Log::error("Index::DiskIO::get_word_separator: out of bounds access denied.");
+  }
+#endif
   WORD_SEPARATOR_TYPE separator;
-  std::memcpy(&separator, &mmap_words[start_pos], sizeof(WORD_SEPARATOR_TYPE));
-  return separator;
+  std::memcpy(&separator
+              ,
+              &
+              mmap_words[start_pos],
+              sizeof
+              (WORD_SEPARATOR_TYPE)
+  );
+  return
+    separator;
 }
 
 void Index::DiskIO::set_word_separator(const size_t start_pos, const WORD_SEPARATOR_TYPE separator)
 {
+#ifndef NDEBUG
+  if (words_size < start_pos + WORD_SEPARATOR_SIZE) {
+    Log::error("Index::DiskIO::set_word_separator: out of bounds access denied.");
+  }
+#endif
   std::memcpy(&mmap_words[start_pos], &separator, sizeof(WORD_SEPARATOR_TYPE));
 }
 
 char Index::DiskIO::get_char_of_word(size_t word_start_pos, uint16_t char_pos) const
 {
+#ifndef NDEBUG
+  if (words_size < word_start_pos + WORD_SEPARATOR_SIZE + char_pos) {
+    Log::error("Index::DiskIO::get_char_of_word: out of bounds access denied.");
+  }
+#endif
   return mmap_words[word_start_pos +
     WORD_SEPARATOR_SIZE + char_pos];
 }
 
 void Index::DiskIO::set_word(const size_t start_pos, const std::string& word, const uint16_t length)
 {
+#ifndef NDEBUG
+  if (words_size < start_pos + length) {
+    Log::error("Index::DiskIO::set_word: out of bounds access denied.");
+  }
+#endif
   std::memcpy(&mmap_words[start_pos], word.data(), length);
 }

--- a/app/Index/DiskIO/DiskIO_WordsF.cpp
+++ b/app/Index/DiskIO/DiskIO_WordsF.cpp
@@ -1,8 +1,14 @@
 #include "../index.h"
+#include "../../Logging/logging.h"
 #include <cstring>
 
 std::vector<WordsFValue> Index::DiskIO::get_words_f() const
 {
+#ifndef NDEBUG
+  if (words_f_size < 26 * sizeof(WordsFValue)) {
+    Log::error("Index::DiskIO::get_words_f: out of bounds access denied.");
+  }
+#endif
   std::vector<WordsFValue> words_f(26);
   std::memcpy(words_f.data(), mmap_words_f.data(), 26 * sizeof(WordsFValue));
   return words_f;
@@ -10,5 +16,10 @@ std::vector<WordsFValue> Index::DiskIO::get_words_f() const
 
 void Index::DiskIO::set_words_f(std::vector<WordsFValue>& words_f)
 {
+#ifndef NDEBUG
+  if (words_f_size < 26 * sizeof(WordsFValue)) {
+    Log::error("Index::DiskIO::set_words_f: out of bounds access denied.");
+  }
+#endif
   std::memcpy(&mmap_words_f[0], words_f.data(), 26 * sizeof(WordsFValue));
 }

--- a/app/Index/DiskIO/DiskIO_WordsF.cpp
+++ b/app/Index/DiskIO/DiskIO_WordsF.cpp
@@ -1,10 +1,5 @@
 #include "../index.h"
-#include "../../Helper/helper.h"
-#include "../../Logging/logging.h"
 #include <cstring>
-#include <filesystem>
-#include <fstream>
-#include <string>
 
 std::vector<WordsFValue> Index::DiskIO::get_words_f() const
 {

--- a/app/Index/DiskIO/DiskIO_WordsF.cpp
+++ b/app/Index/DiskIO/DiskIO_WordsF.cpp
@@ -1,0 +1,14 @@
+#include "../index.h"
+#include "../../Helper/helper.h"
+#include "../../Logging/logging.h"
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+std::vector<WordsFValue> Index::DiskIO::get_words_f() const
+{
+  std::vector<WordsFValue> words_f(26);
+  std::memcpy(words_f.data(), mmap_words_f.data(), 26 * sizeof(WordsFValue));
+  return words_f;
+}

--- a/app/Index/DiskIO/DiskIO_WordsF.cpp
+++ b/app/Index/DiskIO/DiskIO_WordsF.cpp
@@ -12,3 +12,8 @@ std::vector<WordsFValue> Index::DiskIO::get_words_f() const
   std::memcpy(words_f.data(), mmap_words_f.data(), 26 * sizeof(WordsFValue));
   return words_f;
 }
+
+void Index::DiskIO::set_words_f(std::vector<WordsFValue>& words_f)
+{
+  std::memcpy(&mmap_words_f[0], words_f.data(), 26 * sizeof(WordsFValue));
+}

--- a/app/Index/Index.cpp
+++ b/app/Index/Index.cpp
@@ -11,38 +11,28 @@ bool Index::initialized = false;
 bool Index::readonly_initialized = true;
 bool Index::is_mapped = false;
 bool Index::first_time = false;
-int64_t Index::paths_size = 0;
 int64_t Index::paths_size_buffer = 0;
-int64_t Index::paths_count_size = 0;
 int64_t Index::paths_count_size_buffer = 0;
-int64_t Index::words_size = 0;
 int64_t Index::words_size_buffer = 0;
-int64_t Index::words_f_size = 0;
 int64_t Index::words_f_size_buffer = 0;
-int64_t Index::reversed_size = 0;
 int64_t Index::reversed_size_buffer = 0;
-int64_t Index::additional_size = 0;
 int64_t Index::additional_size_buffer = 0;
-mio::mmap_sink Index::mmap_paths;
-mio::mmap_sink Index::mmap_paths_count;
-mio::mmap_sink Index::mmap_words;
-mio::mmap_sink Index::mmap_words_f;
-mio::mmap_sink Index::mmap_reversed;
-mio::mmap_sink Index::mmap_additional;
+
 
 // Config Values, they will be set once and never again while the index is
 // initialized
 std::filesystem::path Index::CONFIG_INDEX_PATH;
 uint16_t Index::CONFIG_LOCK_ACQUISITION_TIMEOUT = 30;
 
-void Index::save_config(const std::filesystem::path &index_path,
-                        const uint16_t lock_aquisition_timeout) {
+void Index::save_config(const std::filesystem::path& index_path,
+                        const uint16_t lock_aquisition_timeout)
+{
   if (initialized) {
     Log::write(3, "Index: save_config: Index was already initialzed, can not "
-                  "save config. Try to uninitialize first.");
+               "save config. Try to uninitialize first.");
   }
   CONFIG_INDEX_PATH =
-      index_path; // Index path validation happens in check_files
+    index_path; // Index path validation happens in check_files
 
   CONFIG_LOCK_ACQUISITION_TIMEOUT = 30; // set to default
   if (lock_aquisition_timeout >= 0 && lock_aquisition_timeout <= 30000) {
@@ -56,47 +46,21 @@ void Index::save_config(const std::filesystem::path &index_path,
 bool Index::is_index_mapped() { return is_mapped; }
 
 void Index::resize(const std::filesystem::path path_to_resize,
-                   const size_t size) {
+                   const size_t size)
+{
   std::error_code ec;
   std::filesystem::resize_file(path_to_resize, size);
   if (ec) {
     Log::error("Index: resize: could not resize file at path: " +
-               (path_to_resize).string() +
-               " with size: " + std::to_string(size) + ".");
+      (path_to_resize).string() +
+      " with size: " + std::to_string(size) + ".");
   }
   Log::write(1, "Index: resize: resized file successfully.");
   return;
 }
 
-int Index::unmap() {
-  std::error_code ec;
-  if (mmap_paths.is_mapped()) {
-    mmap_paths.unmap();
-  }
-  if (mmap_paths_count.is_mapped()) {
-    mmap_paths_count.unmap();
-  }
-  if (mmap_words.is_mapped()) {
-    mmap_words.unmap();
-  }
-  if (mmap_words_f.is_mapped()) {
-    mmap_words_f.unmap();
-  }
-  if (mmap_reversed.is_mapped()) {
-    mmap_reversed.unmap();
-  }
-  if (mmap_additional.is_mapped()) {
-    mmap_additional.unmap();
-  }
-  if (ec) {
-    Log::write(4, "Index: unmap: error when unmapping index files.");
-    return 1;
-  }
-  Log::write(1, "Index: unmap: unmapped all successfully.");
-  return 0;
-}
-
-int Index::sync_all() {
+int Index::sync_all()
+{
   std::error_code ec;
   mmap_paths.sync(ec);
   mmap_words.sync(ec);
@@ -109,47 +73,8 @@ int Index::sync_all() {
   return 0;
 }
 
-int Index::map() {
-  std::error_code ec;
-  if (!mmap_paths.is_mapped()) {
-    mmap_paths =
-        mio::make_mmap_sink((CONFIG_INDEX_PATH / "paths.index").string(), 0,
-                            mio::map_entire_file, ec);
-  }
-  if (!mmap_paths_count.is_mapped()) {
-    mmap_paths_count =
-        mio::make_mmap_sink((CONFIG_INDEX_PATH / "paths_count.index").string(),
-                            0, mio::map_entire_file, ec);
-  }
-  if (!mmap_words.is_mapped()) {
-    mmap_words =
-        mio::make_mmap_sink((CONFIG_INDEX_PATH / "words.index").string(), 0,
-                            mio::map_entire_file, ec);
-  }
-  if (!mmap_words_f.is_mapped()) {
-    mmap_words_f =
-        mio::make_mmap_sink((CONFIG_INDEX_PATH / "words_f.index").string(), 0,
-                            mio::map_entire_file, ec);
-  }
-  if (!mmap_reversed.is_mapped()) {
-    mmap_reversed =
-        mio::make_mmap_sink((CONFIG_INDEX_PATH / "reversed.index").string(), 0,
-                            mio::map_entire_file, ec);
-  }
-  if (!mmap_additional.is_mapped()) {
-    mmap_additional =
-        mio::make_mmap_sink((CONFIG_INDEX_PATH / "additional.index").string(),
-                            0, mio::map_entire_file, ec);
-  }
-  if (ec) {
-    Log::write(3, "Index: map: error when mapping index files.");
-    return 1;
-  }
-  Log::write(1, "Index: map: mapped all successfully.");
-  return 0;
-}
-
-void Index::check_files() {
+void Index::check_files()
+{
   if (!is_config_loaded) {
     Log::error("Index: check_files: config not loaded. can not continue.");
   }
@@ -158,8 +83,8 @@ void Index::check_files() {
   if (!std::filesystem::is_directory(CONFIG_INDEX_PATH)) {
     if (readonly_initialized) {
       Log::error(
-          "Index: check_files: Can not continue, Index is readonly initialized "
-          "but needs writeable action to even be readnly. Exiting");
+        "Index: check_files: Can not continue, Index is readonly initialized "
+        "but needs writeable action to even be readnly. Exiting");
     }
     Log::write(1, "Index: check_files: creating index directory.");
     std::filesystem::create_directories(CONFIG_INDEX_PATH);
@@ -171,12 +96,12 @@ void Index::check_files() {
     }
   }
   if (!std::filesystem::is_directory(CONFIG_INDEX_PATH / "transaction" /
-                                     "backups")) {
+    "backups")) {
     if (readonly_initialized) {
       Log::write(1,
                  "Index: check_files: creating transaction backups directory.");
       std::filesystem::create_directories(CONFIG_INDEX_PATH / "transaction" /
-                                          "backups");
+        "backups");
     }
   }
 
@@ -185,11 +110,11 @@ void Index::check_files() {
     // all index files.
     if (readonly_initialized) {
       Log::error(
-          "Index: check_files: Can not continue, Index is readonly initialized "
-          "but needs writeable action to even be readnly. Exiting");
+        "Index: check_files: Can not continue, Index is readonly initialized "
+        "but needs writeable action to even be readnly. Exiting");
     }
     Log::write(2, "Index: check_files: First time write didn't complete last "
-                  "time. Index possibly corrupt. Deleting to start fresh.");
+               "time. Index possibly corrupt. Deleting to start fresh.");
     std::filesystem::remove(CONFIG_INDEX_PATH / "paths.index");
     std::filesystem::remove(CONFIG_INDEX_PATH / "paths_count.index");
     std::filesystem::remove(CONFIG_INDEX_PATH / "words.index");
@@ -198,34 +123,34 @@ void Index::check_files() {
     std::filesystem::remove(CONFIG_INDEX_PATH / "additional.index");
     std::filesystem::remove(CONFIG_INDEX_PATH / "firsttimewrite.info");
     std::filesystem::remove(CONFIG_INDEX_PATH / "transaction" /
-                            "transaction.list");
+      "transaction.list");
     std::filesystem::remove(CONFIG_INDEX_PATH / "lastupdated_mtime_TEMP.info");
     std::filesystem::remove(CONFIG_INDEX_PATH / "lastupdated_mtime.info");
   }
 
   if (!std::filesystem::exists(CONFIG_INDEX_PATH / "paths.index") ||
-      Helper::file_size(CONFIG_INDEX_PATH / "paths.index") == 0 ||
-      !std::filesystem::exists(CONFIG_INDEX_PATH / "paths_count.index") ||
-      Helper::file_size(CONFIG_INDEX_PATH / "paths_count.index") == 0 ||
-      !std::filesystem::exists(CONFIG_INDEX_PATH / "words.index") ||
-      Helper::file_size(CONFIG_INDEX_PATH / "words.index") == 0 ||
-      !std::filesystem::exists(CONFIG_INDEX_PATH / "words_f.index") ||
-      Helper::file_size(CONFIG_INDEX_PATH / "words_f.index") == 0 ||
-      !std::filesystem::exists(CONFIG_INDEX_PATH / "reversed.index") ||
-      Helper::file_size(CONFIG_INDEX_PATH / "reversed.index") == 0 ||
-      !std::filesystem::exists(CONFIG_INDEX_PATH / "additional.index")
-      // Additional size can be 0 if there aren't any words with more than 4
-      // linked paths.
+    Helper::file_size(CONFIG_INDEX_PATH / "paths.index") == 0 ||
+    !std::filesystem::exists(CONFIG_INDEX_PATH / "paths_count.index") ||
+    Helper::file_size(CONFIG_INDEX_PATH / "paths_count.index") == 0 ||
+    !std::filesystem::exists(CONFIG_INDEX_PATH / "words.index") ||
+    Helper::file_size(CONFIG_INDEX_PATH / "words.index") == 0 ||
+    !std::filesystem::exists(CONFIG_INDEX_PATH / "words_f.index") ||
+    Helper::file_size(CONFIG_INDEX_PATH / "words_f.index") == 0 ||
+    !std::filesystem::exists(CONFIG_INDEX_PATH / "reversed.index") ||
+    Helper::file_size(CONFIG_INDEX_PATH / "reversed.index") == 0 ||
+    !std::filesystem::exists(CONFIG_INDEX_PATH / "additional.index")
+    // Additional size can be 0 if there aren't any words with more than 4
+    // linked paths.
   ) {
     if (readonly_initialized) {
       Log::error(
-          "Index: check_files: Can not continue, Index is readonly initialized "
-          "but needs writeable action to even be readnly. Exiting");
+        "Index: check_files: Can not continue, Index is readonly initialized "
+        "but needs writeable action to even be readnly. Exiting");
     }
     first_time = true;
     Log::write(
-        1,
-        "Index: check_files: index files damaged / not existing, recreating.");
+      1,
+      "Index: check_files: index files damaged / not existing, recreating.");
     std::ofstream{CONFIG_INDEX_PATH / "paths.index"};
     std::ofstream{CONFIG_INDEX_PATH / "paths_count.index"};
     std::ofstream{CONFIG_INDEX_PATH / "words.index"};
@@ -234,18 +159,19 @@ void Index::check_files() {
     std::ofstream{CONFIG_INDEX_PATH / "additional.index"};
     // Remove Transacition file if exist
     std::filesystem::remove(CONFIG_INDEX_PATH / "transaction" /
-                            "transaction.list");
+      "transaction.list");
     std::filesystem::remove(CONFIG_INDEX_PATH / "lastupdated_mtime_TEMP.info");
     std::filesystem::remove(CONFIG_INDEX_PATH / "lastupdated_mtime.info");
   }
   if (ec) {
     Log::error("Index: check_files: error accessing/creating index files in " +
-               (CONFIG_INDEX_PATH).string() + ".");
+      (CONFIG_INDEX_PATH).string() + ".");
   }
   return;
 }
 
-int Index::initialize() {
+int Index::initialize()
+{
   if (!is_config_loaded) {
     Log::write(4, "Index: initialize: config not loaded. can not continue.");
     return 1;
@@ -253,12 +179,11 @@ int Index::initialize() {
   std::error_code ec;
 
   if (!std::filesystem::is_directory(CONFIG_INDEX_PATH)) {
-
     Log::write(1, "Index: initialize: creating index directory.");
     std::filesystem::create_directories(CONFIG_INDEX_PATH, ec);
     if (ec) {
       Log::error("Index: Initialize: Could not create index path. Permission "
-                 "Error? Can not continue like that.");
+        "Error? Can not continue like that.");
     }
   }
 
@@ -274,9 +199,9 @@ int Index::initialize() {
     } // lock file because of check index and transaction execution.
   }
   // just to update internal state
-  unmap();       // unmap anyway incase they are already mapped.
+  unmap(); // unmap anyway incase they are already mapped.
   check_files(); // check if index files exist and create them.
-  map();         // ignore error here as it might fail if file size is 0.
+  map(); // ignore error here as it might fail if file size is 0.
   // get actual sizes of the files.
   paths_size = Helper::file_size(CONFIG_INDEX_PATH / "paths.index");
   paths_count_size = Helper::file_size(CONFIG_INDEX_PATH / "paths_count.index");
@@ -286,9 +211,9 @@ int Index::initialize() {
   additional_size = Helper::file_size(CONFIG_INDEX_PATH / "additional.index");
   // If an error occured exit.
   if (paths_size == -1 || words_size == -1 || words_f_size == -1 ||
-      reversed_size == -1 || additional_size == -1) {
+    reversed_size == -1 || additional_size == -1) {
     Log::error("Index: initialize: could not get actual size of index "
-               "files, exiting.");
+      "files, exiting.");
     return 1;
   }
   is_mapped = true;
@@ -296,25 +221,25 @@ int Index::initialize() {
   // check if transaction file exists
   if (readonly_initialized) {
     if (std::filesystem::exists(CONFIG_INDEX_PATH / "transaction" /
-                                "transaction.list")) {
+      "transaction.list")) {
       Log::write(2, "Index: a transaction file still exists. Checking if Index "
-                    "needs to be repaired.");
+                 "needs to be repaired.");
       if (execute_transactions() == 1) {
         Log::error("Index: while checking transaction file an error occured. "
-                   "Exiting.");
+          "Exiting.");
       }
       Log::write(
-          2,
-          "Index: transaction file successfully checked. Finishing startup.");
+        2,
+        "Index: transaction file successfully checked. Finishing startup.");
     }
     // removing all backups because they are not needed anymore.
     std::filesystem::remove_all(CONFIG_INDEX_PATH / "transaction" / "backups");
     if (!std::filesystem::is_directory(CONFIG_INDEX_PATH / "transaction" /
-                                       "backups")) {
+      "backups")) {
       Log::write(
-          1, "Index: intitialize: creating transactions backups directory.");
+        1, "Index: intitialize: creating transactions backups directory.");
       std::filesystem::create_directories(CONFIG_INDEX_PATH / "transaction" /
-                                          "backups");
+        "backups");
     }
   }
   unlock(true);
@@ -323,7 +248,8 @@ int Index::initialize() {
   return 0;
 }
 
-int Index::uninitialize() {
+int Index::uninitialize()
+{
   if (!is_config_loaded) {
     Log::write(4, "Index: uninitialize: config not loaded. can not continue.");
     return 1;
@@ -340,12 +266,13 @@ int Index::uninitialize() {
   return 0;
 }
 
-int Index::add(index_combine_data &index_to_add) {
+int Index::add(index_combine_data& index_to_add)
+{
   std::error_code ec;
   if (!initialized || lock_status(false) <= 0) {
     Log::write(3, "Index: Can not add because index is not initialized or "
-                  "Index is locked and read-only most likely due to another "
-                  "process doing a merge or first time add.");
+               "Index is locked and read-only most likely due to another "
+               "process doing a merge or first time add.");
     return 1;
   }
   if (readonly_initialized) {
@@ -354,35 +281,39 @@ int Index::add(index_combine_data &index_to_add) {
     if (readonly_initialized || !initialized) {
       // if it is still readonly we return
       Log::write(
-          3, "Index: could not initialize wihtout becomign readonly, this "
-             "means some initialization were not completed and manipulating "
-             "the index now could result in Data loss, this is most likely "
-             "because another process is writing to it right now.");
+        3, "Index: could not initialize wihtout becomign readonly, this "
+        "means some initialization were not completed and manipulating "
+        "the index now could result in Data loss, this is most likely "
+        "because another process is writing to it right now.");
       return 1;
     }
   }
   if (!lock(false)) {
     // Acquire lock
     Log::write(3, "Index: Can not add because acquiring lock failed. Check "
-                  "previous logs");
+               "previous logs");
     return 1; // failed to acquire lock.
   }
   if (first_time) {
     first_time = false;
-    std::ofstream{CONFIG_INDEX_PATH /
-                  "firsttimewrite.info"}; // add file to signal firsttimewrite
-                                          // is in progress. Delete after it
-                                          // is successfully done.
+    std::ofstream{
+      CONFIG_INDEX_PATH /
+      "firsttimewrite.info"
+    }; // add file to signal firsttimewrite
+    // is in progress. Delete after it
+    // is successfully done.
     if (add_new(index_to_add) == 0) {
       std::filesystem::remove(CONFIG_INDEX_PATH / "firsttimewrite.info");
       unlock(false); // unlock after done
       return 0;
-    } else {
+    }
+    else {
       // if an error occured exit.
       Log::error("Index: Frist time write failed. Exiting. Corupted index "
-                 "files will be deleted on startup.");
+        "files will be deleted on startup.");
     }
-  } else {
+  }
+  else {
     if (merge(index_to_add) == 1) {
       unlock(false); // unlock after done
       return 1;

--- a/app/Index/Index.cpp
+++ b/app/Index/Index.cpp
@@ -11,12 +11,13 @@ bool Index::initialized = false;
 bool Index::readonly_initialized = true;
 bool Index::is_mapped = false;
 bool Index::first_time = false;
-int64_t Index::paths_size_buffer = 0;
-int64_t Index::paths_count_size_buffer = 0;
-int64_t Index::words_size_buffer = 0;
-int64_t Index::words_f_size_buffer = 0;
-int64_t Index::reversed_size_buffer = 0;
-int64_t Index::additional_size_buffer = 0;
+size_t Index::paths_size_buffer = 0;
+size_t Index::paths_count_size_buffer = 0;
+size_t Index::words_size_buffer = 0;
+size_t Index::words_f_size_buffer = 0;
+size_t Index::reversed_size_buffer = 0;
+size_t Index::additional_size_buffer = 0;
+Index::DiskIO Index::disk_io;
 
 
 // Config Values, they will be set once and never again while the index is

--- a/app/Index/Index_Add.cpp
+++ b/app/Index/Index_Add.cpp
@@ -73,7 +73,7 @@ int Index::add_new(index_combine_data& index_to_add)
   // write the word count as 4 bytes values each to disk.
   file_location = 0;
   for (size_t i = 0; i < index_to_add.paths_count.size(); ++i) {
-    disk_io.set_path_separator(file_location + 1, index_to_add.paths_count[i]);
+    disk_io.set_path_count(file_location + 1, index_to_add.paths_count[i]);
     // +1 because path_ids start from 1 and here we start from 0.
     file_location += 4;
   }

--- a/app/Index/Index_Add.cpp
+++ b/app/Index/Index_Add.cpp
@@ -57,7 +57,7 @@ int Index::add_new(index_combine_data& index_to_add)
 
   // write all paths to disk with a offset in beetween.
   for (const std::string& path : index_to_add.paths) {
-    size_t path_length = path.length();
+    const size_t path_length = path.length();
     disk_io.set_path_separator(file_location, path_length);
     file_location += 2;
     disk_io.set_path(file_location, path, path_length);
@@ -71,9 +71,9 @@ int Index::add_new(index_combine_data& index_to_add)
 
   // paths_count
   // write the word count as 4 bytes values each to disk.
-  file_location = 0;
+  file_location = 1;
   for (size_t i = 0; i < index_to_add.paths_count.size(); ++i) {
-    disk_io.set_path_count(file_location + 1, index_to_add.paths_count[i]);
+    disk_io.set_path_count(i + 1, index_to_add.paths_count[i]);
     // +1 because path_ids start from 1 and here we start from 0.
     file_location += 4;
   }

--- a/app/Index/Index_Add.cpp
+++ b/app/Index/Index_Add.cpp
@@ -5,7 +5,8 @@
 #include <filesystem>
 #include <string>
 
-int Index::add_new(index_combine_data &index_to_add) {
+int Index::add_new(index_combine_data& index_to_add)
+{
   std::error_code ec;
   Log::write(2, "Index: add: first time write.");
   // paths
@@ -15,61 +16,56 @@ int Index::add_new(index_combine_data &index_to_add) {
   paths_count_size_buffer = index_to_add.paths.size() * 4;
 
   words_size_buffer =
-      index_to_add.words_size +
-      (index_to_add.words_and_reversed.size() * WORD_SEPARATOR_SIZE);
+    index_to_add.words_size +
+    (index_to_add.words_and_reversed.size() * WORD_SEPARATOR_SIZE);
 
   words_f_size_buffer =
-      26 *
-      (8 + WORDS_F_LOCATION_SIZE); // uint64_t stored as 8 bytes(disk location))
-                                   // + PATH_ID_TYPE stored as 4 bytes(disk id)
-                                   // for each letter in the alphabet.
+    26 *
+    (8 + WORDS_F_LOCATION_SIZE); // uint64_t stored as 8 bytes(disk location))
+  // + PATH_ID_TYPE stored as 4 bytes(disk id)
+  // for each letter in the alphabet.
 
   reversed_size_buffer =
-      index_to_add.words_and_reversed.size() * REVERSED_ENTRY_SIZE;
+    index_to_add.words_and_reversed.size() * REVERSED_ENTRY_SIZE;
   additional_size_buffer = 0;
-  for (const words_reversed &additional_reversed_counter :
+  for (const words_reversed& additional_reversed_counter :
        index_to_add.words_and_reversed) {
     if (additional_reversed_counter.reversed.size() <=
-        REVERSED_PATH_LINKS_AMOUNT) {
+      REVERSED_PATH_LINKS_AMOUNT) {
       continue; // if it fits in only a reverse nlock no additional is
-                // requiered.
+      // requiered.
     }
     additional_size_buffer +=
-        (additional_reversed_counter.reversed.size() -
-         REVERSED_PATH_LINKS_AMOUNT + ADDITIONAL_PATH_LINKS_AMOUNT - 1) /
-        ADDITIONAL_PATH_LINKS_AMOUNT; // celling divsion to round up to
-                                      // the next big number.
+      (additional_reversed_counter.reversed.size() -
+        REVERSED_PATH_LINKS_AMOUNT + ADDITIONAL_PATH_LINKS_AMOUNT - 1) /
+      ADDITIONAL_PATH_LINKS_AMOUNT; // celling divsion to round up to
+    // the next big number.
   }
   additional_size_buffer *=
-      ADDITIONAL_ENTRY_SIZE; // amount of additionals times the bytes per
-                             // additional
+    ADDITIONAL_ENTRY_SIZE; // amount of additionals times the bytes per
+  // additional
 
   // resize
-  unmap();
+  disk_io.unmap();
   resize(CONFIG_INDEX_PATH / "paths.index", paths_size_buffer);
   resize(CONFIG_INDEX_PATH / "paths_count.index", paths_count_size_buffer);
   resize(CONFIG_INDEX_PATH / "words.index", words_size_buffer);
   resize(CONFIG_INDEX_PATH / "words_f.index", words_f_size_buffer);
   resize(CONFIG_INDEX_PATH / "reversed.index", reversed_size_buffer);
   resize(CONFIG_INDEX_PATH / "additional.index", additional_size_buffer);
-  map();
+  disk_io.map(CONFIG_INDEX_PATH);
 
   // write all paths to disk with a offset in beetween.
-  for (const std::string &path : index_to_add.paths) {
-    PathOffset offset = {};
-    offset.offset = path.length();
-    mmap_paths[file_location] = offset.bytes[0];
-    ++file_location;
-    mmap_paths[file_location] = offset.bytes[1];
-    ++file_location;
-    for (const char &c : path) {
-      mmap_paths[file_location] = c;
-      ++file_location;
-    }
+  for (const std::string& path : index_to_add.paths) {
+    size_t path_length = path.length();
+    disk_io.set_path_separator(file_location, path_length);
+    file_location += 2;
+    disk_io.set_path(file_location, path, path_length);
+    file_location += path_length;
   }
-  paths_size = file_location;
+  paths_size_buffer = file_location;
   index_to_add.paths.clear(); // free memory as we have written this to memory
-                              // already and don't need it anymore.
+  // already and don't need it anymore.
 
   Log::write(2, "Index: add: paths written.");
 
@@ -77,13 +73,11 @@ int Index::add_new(index_combine_data &index_to_add) {
   // write the word count as 4 bytes values each to disk.
   file_location = 0;
   for (size_t i = 0; i < index_to_add.paths_count.size(); ++i) {
-    PathsCountItem new_paths_count{index_to_add.paths_count[i]};
-    for (int j = 0; j < 4; ++j) {
-      mmap_paths_count[file_location] = new_paths_count.bytes[j];
-      ++file_location;
-    }
+    disk_io.set_path_separator(i + 1, index_to_add.paths_count[i]);
+    // +1 because path_ids start from 1 and here we start from 0.
+    file_location += 4;
   }
-  paths_count_size = file_location;
+  paths_count_size_buffer = file_location;
   index_to_add.paths_count.clear(); // free memory
 
   Log::write(2, "Index: add: paths_count written.");
@@ -94,33 +88,27 @@ int Index::add_new(index_combine_data &index_to_add) {
   file_location = 0;
   size_t on_disk_id = 0;
 
-  for (const words_reversed &word : index_to_add.words_and_reversed) {
+  for (const auto& [word, reversed] : index_to_add.words_and_reversed) {
     // check if the first char is different from the last. if so, save the
     // location to words_f. words_reversed is sorted already.
-    if (word.word[0] !=
-        current_char) { // save file location if a new letter appears.
-      current_char = word.word[0];
+    if (word[0] !=
+      current_char) {
+      // save file location if a new letter appears.
+      current_char = word[0];
       words_f[current_char - 'a'].location = file_location;
       words_f[current_char - 'a'].id = on_disk_id;
     }
     // We use a 1byte seperator beetween each word. We also directly use it to
     // indicate how long the word is.
-    size_t word_length = word.word.length();
-    WordSeperator word_seperator;
-    word_seperator.seperator = word_length;
+    size_t word_length = word.length();
+    disk_io.set_word_separator(file_location, word_length);
+    file_location += WORD_SEPARATOR_SIZE;
 
-    for (uint8_t i = 0; i < WORD_SEPARATOR_SIZE; ++i) {
-      mmap_words[file_location] = word_seperator.bytes[i];
-      ++file_location;
-    }
-
-    for (const char c : word.word) {
-      mmap_words[file_location] = c;
-      ++file_location;
-    }
+    disk_io.set_word(file_location, word, word_length);
+    file_location += word_length;
     ++on_disk_id;
   }
-  words_size = file_location;
+  words_size_buffer = file_location;
   Log::write(2, "indexer: add: words written");
 
   // write words_f
@@ -128,57 +116,57 @@ int Index::add_new(index_combine_data &index_to_add) {
   // check words_f. If any character is 0, set it to the value of the next non
   // 0 word. This can happen if no word with a specific letter occured. We set
   // it to the next char start.
-  for (int i = 1; i < 26; ++i) { // first one is always 0 so we skip it.
+  for (int i = 1; i < 26; ++i) {
+    // first one is always 0 so we skip it.
     // we add it to a list of items with 0. If we find one with a number we
     // write all in the list to the same number. At the end if there are still 0
     // in the list we write it with the last location of the file.
     if (words_f[i].location == 0) {
       to_set.push_back(i);
-    } else {
-      for (const int &j : to_set) {
+    }
+    else {
+      for (const int& j : to_set) {
         words_f[j] = words_f[i];
       }
       to_set.clear();
     }
   }
-  for (const size_t &j :
-       to_set) { // if there are any left we set them to the end of words
+  for (const size_t& j :
+       to_set) {
+    // if there are any left we set them to the end of words
     words_f[j].location = file_location;
     words_f[j].id = on_disk_id;
   }
 
-  file_location = 0;
-  for (const WordsFValue &word_f : words_f) {
-    std::memcpy(&mmap_words_f[file_location], &word_f.bytes[0],
-                (8 + WORDS_F_LOCATION_SIZE));
-    file_location += (8 + WORDS_F_LOCATION_SIZE);
-  }
+  disk_io.set_words_f(words_f);
+  file_location = 26 * (8 + WORDS_F_LOCATION_SIZE);
 
-  words_f_size = file_location;
+  words_f_size_buffer = file_location;
   Log::write(2, "indexer: add: words_f written");
 
   // reversed & additional
   file_location = 0;
-  size_t additional_file_location = 0;
+  size_t word_id = 0;
   size_t additional_id = 1;
-  for (const words_reversed &reversed : index_to_add.words_and_reversed) {
+  for (const words_reversed& reversed : index_to_add.words_and_reversed) {
     // check if we need only a reversed block or also additionals.
     ReversedBlock current_ReversedBlock{};
     if (reversed.reversed.size() <= REVERSED_PATH_LINKS_AMOUNT) {
       // we just need a reversed so we will write that.
       size_t i = 0;
-      for (const PATH_ID_TYPE &r_id : reversed.reversed) {
+      for (const PATH_ID_TYPE& r_id : reversed.reversed) {
         current_ReversedBlock.ids.path[i] =
-            r_id + 1; // paths are indexed from 1
+          r_id + 1; // paths are indexed from 1
         ++i;
       }
-    } else {
+    }
+    else {
       // create additional blocks and write if full. At the end write current
       // additional that has not been written.
       size_t additional_i = 0;
       size_t reversed_i = 0;
       AdditionalBlock additional{};
-      for (const PATH_ID_TYPE &path_id : reversed.reversed) {
+      for (const PATH_ID_TYPE& path_id : reversed.reversed) {
         if (reversed_i < REVERSED_PATH_LINKS_AMOUNT) {
           current_ReversedBlock.ids.path[reversed_i] = path_id + 1;
           ++reversed_i;
@@ -189,16 +177,14 @@ int Index::add_new(index_combine_data &index_to_add) {
           ++reversed_i;
         }
         if (additional_i ==
-            ADDITIONAL_PATH_LINKS_AMOUNT) { // the next additional id
-                                            // field.
+          ADDITIONAL_PATH_LINKS_AMOUNT) {
+          // the next additional id
+          // field.
           additional.ids.additional[0] = additional_id + 1;
           additional_i = 0;
 
-          uint16_t byte_counter = 0;
-          for (const char &byte : additional.bytes) {
-            mmap_additional[additional_file_location] = byte;
-            ++additional_file_location;
-          }
+          disk_io.set_additional(additional, additional_id);
+
           ++additional_id;
           additional = {};
         }
@@ -206,21 +192,16 @@ int Index::add_new(index_combine_data &index_to_add) {
         ++additional_i;
       }
       if (additional_i != 0) {
-        for (const char &byte : additional.bytes) {
-          mmap_additional[additional_file_location] = byte;
-          ++additional_file_location;
-        }
+        disk_io.set_additional(additional, additional_id);
         ++additional_id;
       }
     }
 
-    // write reversed block
-    for (int i = 0; i < REVERSED_ENTRY_SIZE; ++i) {
-      mmap_reversed[file_location] = current_ReversedBlock.bytes[i];
-      ++file_location;
-    }
+    disk_io.set_reversed(current_ReversedBlock, word_id);
+    file_location += REVERSED_ENTRY_SIZE;
+    ++word_id;
   }
-  reversed_size = file_location;
+  reversed_size_buffer = file_location;
   Log::write(2, "indexer: add: reversed and additonal written");
 
   // we do not need to resize because we already know the size accuratly.

--- a/app/Index/Index_Add.cpp
+++ b/app/Index/Index_Add.cpp
@@ -73,7 +73,7 @@ int Index::add_new(index_combine_data& index_to_add)
   // write the word count as 4 bytes values each to disk.
   file_location = 0;
   for (size_t i = 0; i < index_to_add.paths_count.size(); ++i) {
-    disk_io.set_path_separator(i + 1, index_to_add.paths_count[i]);
+    disk_io.set_path_separator(file_location + 1, index_to_add.paths_count[i]);
     // +1 because path_ids start from 1 and here we start from 0.
     file_location += 4;
   }

--- a/app/Index/Index_Add.cpp
+++ b/app/Index/Index_Add.cpp
@@ -71,7 +71,7 @@ int Index::add_new(index_combine_data& index_to_add)
 
   // paths_count
   // write the word count as 4 bytes values each to disk.
-  file_location = 1;
+  file_location = 0;
   for (size_t i = 0; i < index_to_add.paths_count.size(); ++i) {
     disk_io.set_path_count(i + 1, index_to_add.paths_count[i]);
     // +1 because path_ids start from 1 and here we start from 0.

--- a/app/Index/Index_Check.cpp
+++ b/app/Index/Index_Check.cpp
@@ -193,7 +193,7 @@ bool Index::expensive_index_check(const bool verbose_output)
       // accessing invalid data. The index format would allow it
       // but it could be corrupted and not detected.
       next_path_end = disk_io.get_path_separator(paths_check_size);
-      ++paths_check_size;
+      paths_check_size += 2;
       if (!(paths_check_size + next_path_end <
         disk_io.get_paths_size() + 1)) {
         Log::write(4, "Index: Check: Paths index too small to read next path.");

--- a/app/Index/Index_Check.cpp
+++ b/app/Index/Index_Check.cpp
@@ -22,7 +22,7 @@ bool Index::expensive_index_check(const bool verbose_output)
     return false;
   }
   if (is_mapped == false) {
-    map();
+    disk_io.map(CONFIG_INDEX_PATH);
   }
 
   // Acquire Lock (even though we don't write anything we don't want to the
@@ -49,13 +49,8 @@ bool Index::expensive_index_check(const bool verbose_output)
   char disk_first_char = 'a';
   std::string previous_word = "";
 
-  while (words_check_size < words_size) {
-    // read the one byte word separator.
-    WordSeperator word_sep;
-    for (uint8_t i = 0; i < WORD_SEPARATOR_SIZE; ++i) {
-      word_sep.bytes[i] = mmap_words[words_check_size + i];
-    }
-    WORD_SEPARATOR_TYPE word_seperator = word_sep.seperator;
+  while (words_check_size < disk_io.get_words_size()) {
+    WORD_SEPARATOR_TYPE word_seperator = disk_io.get_word_separator(words_check_size);
     if (word_seperator <= 0) {
       // can't be 0 or lower than 0. index corrupt most likely
       Log::write(4, "Index: Check: Word Seperator is 0 or lower. This can not "
@@ -67,7 +62,7 @@ bool Index::expensive_index_check(const bool verbose_output)
       return false;
     }
 
-    if (words_check_size + word_seperator >= words_size) {
+    if (words_check_size + word_seperator >= disk_io.get_words_size()) {
       Log::write(4, "Index: Check: Word Seperator would go over words index.");
       if (verbose_output) {
         std::cout
@@ -77,11 +72,9 @@ bool Index::expensive_index_check(const bool verbose_output)
     }
 
     // check if new words_f
-    if (disk_first_char <
-      mmap_words[words_check_size +
-        WORD_SEPARATOR_SIZE]) {
+    if (disk_first_char < disk_io.get_char_of_word(words_check_size, 0)) {
       // + WORD_SEPARATOR_SIZE because of the word separator
-      disk_first_char = mmap_words[words_check_size + WORD_SEPARATOR_SIZE];
+      disk_first_char = disk_io.get_char_of_word(words_check_size, 0);
       words_f_comparison[disk_first_char - 'a'] = {
         .location = words_check_size + WORD_SEPARATOR_SIZE, .id = words_check_count
       };
@@ -89,7 +82,7 @@ bool Index::expensive_index_check(const bool verbose_output)
 
     std::string current_word = "";
     for (int i = 0; i < word_seperator; ++i) {
-      char c = mmap_words[words_check_size + WORD_SEPARATOR_SIZE + i];
+      char c = disk_io.get_char_of_word(words_check_size, i);
       if (c < 'a' || c > 'z') {
         // Invalid. TODO: allow customising the range
         Log::write(4, "Index: Check: Char is not a-z. Invalid for a word char.");
@@ -116,7 +109,7 @@ bool Index::expensive_index_check(const bool verbose_output)
     words_check_size +=
       word_seperator + WORD_SEPARATOR_SIZE;
   }
-  if (words_check_size != words_size) {
+  if (words_check_size != disk_io.get_words_size()) {
     Log::write(4, "Index: Check: Word size does not match up with counted size.");
     if (verbose_output) {
       std::cout
@@ -129,7 +122,7 @@ bool Index::expensive_index_check(const bool verbose_output)
   // 1. Validate size
   // 2. Compare values to previously created one (if our is 0 just validate it is the same as the next non zero)
 
-  if (words_f_size != (8 + WORDS_F_LOCATION_SIZE) * 26) {
+  if (disk_io.get_words_f_size() != (8 + WORDS_F_LOCATION_SIZE) * 26) {
     Log::write(4, "Index: Check: Words_f size is wrong.");
     if (verbose_output) {
       std::cout
@@ -139,12 +132,7 @@ bool Index::expensive_index_check(const bool verbose_output)
   }
 
   // copy words_f into memory
-  std::vector<WordsFValue> words_f(26);
-  for (int i = 0; i < 26; ++i) {
-    std::memcpy(&words_f[i].bytes[0],
-                &mmap_words_f[i * (8 + WORDS_F_LOCATION_SIZE)],
-                (8 + WORDS_F_LOCATION_SIZE));
-  }
+  std::vector<WordsFValue> words_f = disk_io.get_words_f();
 
   if (words_f[0].id != 0 || words_f[0].location != 0) {
     Log::write(4, "Index: Check: Word_f: location and/or id for letter a is not 0 which is invalid.");
@@ -199,21 +187,15 @@ bool Index::expensive_index_check(const bool verbose_output)
   uint64_t paths_check_count = 0;
   uint16_t next_path_end = 0; // if 0 the next 2 values are the header.
 
-  while (paths_check_size < paths_size) {
-    if (paths_check_size + 1 < paths_size) {
+  while (paths_check_size < disk_io.get_paths_size()) {
+    if (paths_check_size + 1 < disk_io.get_paths_size()) {
       // we read 1 byte ahead for the offset to prevent
       // accessing invalid data. The index format would allow it
       // but it could be corrupted and not detected.
-      PathOffset path_offset;
-      // we read the offset so we know how long the path is and where the next
-      // path starts.
-      path_offset.bytes[0] = mmap_paths[paths_check_size];
-      ++paths_check_size;
-      path_offset.bytes[1] = mmap_paths[paths_check_size];
-      next_path_end = path_offset.offset;
+      next_path_end = disk_io.get_path_separator(paths_check_size);
       ++paths_check_size;
       if (!(paths_check_size + next_path_end <
-        paths_size + 1)) {
+        disk_io.get_paths_size() + 1)) {
         Log::write(4, "Index: Check: Paths index too small to read next path.");
         if (verbose_output) {
           std::cout
@@ -237,7 +219,7 @@ bool Index::expensive_index_check(const bool verbose_output)
   // Paths count
   // 1. Just make sure the size is 4 * amount of paths
 
-  if (paths_count_size != paths_check_count * 4) {
+  if (disk_io.get_paths_count_size() != paths_check_count * 4) {
     Log::write(4, "Index: Check: Paths count size is not valid.");
     if (verbose_output) {
       std::cout
@@ -252,8 +234,8 @@ bool Index::expensive_index_check(const bool verbose_output)
   // 3. Read reversed, make sure no duplicate path ids are found and all path ids are valid. Also make sure there are no gaps
   // 4. Read additional and make sure it's valid. Keep track of all additionals. Do the same for each path id in additional as in reversed and follow all additionals
 
-  if (reversed_size % REVERSED_ENTRY_SIZE != 0 ||
-    additional_size
+  if (disk_io.get_reversed_size() % REVERSED_ENTRY_SIZE != 0 ||
+    disk_io.get_additional_size()
     % ADDITIONAL_ENTRY_SIZE != 0) {
     Log::write(4, "Index: Check: Reversed and/or Additional size is invalid.");
     if (verbose_output) {
@@ -262,7 +244,7 @@ bool Index::expensive_index_check(const bool verbose_output)
     }
     return false;
   }
-  if (reversed_size != words_check_count * REVERSED_ENTRY_SIZE) {
+  if (disk_io.get_reversed_size() != words_check_count * REVERSED_ENTRY_SIZE) {
     Log::write(4, "Index: Check: Reversed size does not match up with amounts of words.");
     if (verbose_output) {
       std::cout
@@ -283,9 +265,7 @@ bool Index::expensive_index_check(const bool verbose_output)
     bool found_path = false;
     bool found_empty = false;
 
-    ReversedBlock* disk_reversed = reinterpret_cast<ReversedBlock*>(
-      &mmap_reversed[reversed_check_count * REVERSED_ENTRY_SIZE]);
-
+    ReversedBlock* disk_reversed = disk_io.get_reversed_pointer(reversed_check_count);
     for (PATH_ID_TYPE i = 0; i < REVERSED_PATH_LINKS_AMOUNT;
          ++i) {
       if (disk_reversed->ids.path[i] == 0) {
@@ -333,7 +313,7 @@ bool Index::expensive_index_check(const bool verbose_output)
         }
         return false;
       }
-      if ((current_additional * ADDITIONAL_ENTRY_SIZE) > additional_size) {
+      if ((current_additional * ADDITIONAL_ENTRY_SIZE) > disk_io.get_additional_size()) {
         Log::write(4, "Index: Check: Additional linked id is invalid.");
         if (verbose_output) {
           std::cout
@@ -352,8 +332,7 @@ bool Index::expensive_index_check(const bool verbose_output)
 
       used_additional_ids.insert(current_additional);
 
-      AdditionalBlock* disk_additional = reinterpret_cast<AdditionalBlock*>(
-        &mmap_additional[(current_additional - 1) * ADDITIONAL_ENTRY_SIZE]);
+      AdditionalBlock* disk_additional = disk_io.get_additional_pointer(current_additional);
 
       for (PATH_ID_TYPE i = 0; i < ADDITIONAL_PATH_LINKS_AMOUNT;
            ++i) {

--- a/app/Index/Index_Merge.cpp
+++ b/app/Index/Index_Merge.cpp
@@ -36,9 +36,7 @@ std::string Index::generate_new_additionals(index_combine_data& index_to_add, co
       if (index_to_add.words_and_reversed[local_word_count].reversed.size() ==
         0) {
         // If this will be the last one we will add 0.
-        additional_transaction_content += {
-          reinterpret_cast<const char*>(0), ADDITIONAL_ID_LINK_SIZE
-        };
+        additional_transaction_content += (ADDITIONAL_ID_LINK_SIZE, '\0');
         in_additional_counter = 0;
         break;
       }
@@ -54,9 +52,9 @@ std::string Index::generate_new_additionals(index_combine_data& index_to_add, co
   if (in_additional_counter != 0) {
     for (; in_additional_counter < ADDITIONAL_PATH_LINKS_AMOUNT;
            ++in_additional_counter) {
-      additional_transaction_content += {reinterpret_cast<const char*>(0), PATH_ID_LINK_SIZE};
+      additional_transaction_content += (PATH_ID_LINK_SIZE, '\0');
     }
-    additional_transaction_content += {reinterpret_cast<const char*>(0), ADDITIONAL_ID_LINK_SIZE};
+    additional_transaction_content += (ADDITIONAL_ID_LINK_SIZE, '\0');
   }
 
   return additional_transaction_content;
@@ -386,9 +384,10 @@ void Index::add_new_word(index_combine_data& index_to_add,
   }
 
   // convert to bytes and add insertion
-  for (size_t i = 0; i < REVERSED_ENTRY_SIZE; ++i) {
-    new_reversed.content.push_back(current_ReversedBlock.bytes[i]);
-  }
+  new_reversed.content = std::string(
+    reinterpret_cast<const char*>(current_ReversedBlock.bytes),
+    REVERSED_ENTRY_SIZE
+  );
   reversed_insertions.push_back(new_reversed);
 }
 

--- a/app/Index/Index_Merge.cpp
+++ b/app/Index/Index_Merge.cpp
@@ -36,7 +36,7 @@ std::string Index::generate_new_additionals(index_combine_data& index_to_add, co
       if (index_to_add.words_and_reversed[local_word_count].reversed.size() ==
         0) {
         // If this will be the last one we will add 0.
-        additional_transaction_content += (ADDITIONAL_ID_LINK_SIZE, '\0');
+        additional_transaction_content += std::string(ADDITIONAL_ID_LINK_SIZE, '\0');
         in_additional_counter = 0;
         break;
       }
@@ -52,9 +52,9 @@ std::string Index::generate_new_additionals(index_combine_data& index_to_add, co
   if (in_additional_counter != 0) {
     for (; in_additional_counter < ADDITIONAL_PATH_LINKS_AMOUNT;
            ++in_additional_counter) {
-      additional_transaction_content += (PATH_ID_LINK_SIZE, '\0');
+      additional_transaction_content += std::string(PATH_ID_LINK_SIZE, '\0');
     }
-    additional_transaction_content += (ADDITIONAL_ID_LINK_SIZE, '\0');
+    additional_transaction_content += std::string(ADDITIONAL_ID_LINK_SIZE, '\0');
   }
 
   return additional_transaction_content;
@@ -310,7 +310,7 @@ void Index::add_new_word(index_combine_data& index_to_add,
   const size_t word_length =
     index_to_add.words_and_reversed[local_word_count].word.length();
 
-  std::string content = {reinterpret_cast<const char*>(word_length), WORD_SEPARATOR_SIZE};
+  auto content = std::string(reinterpret_cast<const char*>(&word_length), WORD_SEPARATOR_SIZE);
   content += index_to_add.words_and_reversed[local_word_count].word;
 
   // when we call this function, on_disk_count is right before the words starts.
@@ -618,7 +618,8 @@ int Index::merge(index_combine_data& index_to_add)
           if (disk_io.get_path_count(on_disk_id) !=
             new_path_count) {
             // if it is different we create a transaction to correct it.
-            std::string count_overwrite_content = *reinterpret_cast<std::string*>(&new_path_count);
+            std::string count_overwrite_content = std::string(reinterpret_cast<const char*>(&new_path_count),
+                                                              sizeof(uint32_t));
             Transaction count_to_overwrite_path_transaction{
               {
                 {

--- a/app/Index/Index_Merge.cpp
+++ b/app/Index/Index_Merge.cpp
@@ -352,7 +352,7 @@ void Index::add_new_word(index_combine_data& index_to_add,
     }
   }
   if (index_to_add.words_and_reversed[local_word_count].reversed.size() == 0) {
-    // If we have added all new links we don't need to set an additinal id.
+    // If we have added all new links we don't need to set an additional id.
     current_ReversedBlock.ids.additional[0] = 0;
   }
   else {
@@ -947,7 +947,7 @@ int Index::merge(index_combine_data& index_to_add)
   // thing. When we add custom words_f length then we can make a better
   // implementation that is faster and saves memory and space.
   Transaction words_f_new{{{0, 2, 0, 0, 1, ((8 + WORDS_F_LOCATION_SIZE) * 26)}}, ""};
-  words_f_new.content.reserve(((8 + WORDS_F_LOCATION_SIZE) * 26));
+  words_f_new.content.resize(((8 + WORDS_F_LOCATION_SIZE) * 26));
   uint64_t all_size = 0;
   uint64_t all_id_change = 0;
   for (int i = 0; i < 26; ++i) {

--- a/app/Index/Index_Merge.cpp
+++ b/app/Index/Index_Merge.cpp
@@ -64,8 +64,7 @@ void Index::add_reversed_to_word(
       Log::error("Index: path_ids_from_word_id: to search word id would be at "
         "nonexisting location. Index most likely corrupt. Exiting");
     }
-    AdditionalBlock* disk_additional = reinterpret_cast<AdditionalBlock*>(
-      &mmap_additional[(current_additional - 1) * ADDITIONAL_ENTRY_SIZE]);
+    AdditionalBlock* disk_additional = disk_io.get_additional_pointer(current_additional);
     // load the current additional block. -1 because additional IDs start at 1.
     size_t i = 0;
     while (index_to_add.words_and_reversed[local_word_count].reversed.size() !=
@@ -85,9 +84,7 @@ void Index::add_reversed_to_word(
               "Index: path_ids_from_word_id: to search word id would be at "
               "nonexisting location. Index most likely corrupt. Exiting");
           }
-          disk_additional = reinterpret_cast<AdditionalBlock*>(
-            &mmap_additional[(current_additional - 1) *
-              ADDITIONAL_ENTRY_SIZE]);
+          disk_additional = disk_io.get_additional_pointer(current_additional);
           i = 0;
           additional_free.push_back(
             {

--- a/app/Index/Index_Merge.cpp
+++ b/app/Index/Index_Merge.cpp
@@ -548,7 +548,7 @@ int Index::merge(index_combine_data& index_to_add)
 {
   Log::write(1, "indexer: add: adding to existing index.");
   std::error_code ec;
-  map();
+  disk_io.map(CONFIG_INDEX_PATH);
 
   std::vector<Transaction> transactions;
   std::vector<Transaction> move_transactions;

--- a/app/Index/Index_Merge.cpp
+++ b/app/Index/Index_Merge.cpp
@@ -800,7 +800,6 @@ int Index::merge(index_combine_data& index_to_add)
     char word_first_char = disk_io.get_char_of_word(on_disk_count, 0);
     if (disk_first_char <
       word_first_char) {
-      // + WORD_SEPARATOR_SIZE because of the word seperator
       disk_first_char = word_first_char;
     }
 

--- a/app/Index/Index_Search.cpp
+++ b/app/Index/Index_Search.cpp
@@ -351,7 +351,7 @@ Index::search_word_list(std::vector<std::pair<std::string, bool>>& search_words,
   return results;
 }
 
-// return am unordered map of ID and path string.
+// return an unordered map of ID and path string.
 std::unordered_map<PATH_ID_TYPE, std::string>
 Index::id_to_path_string(std::vector<search_path_ids_return>& path_ids)
 {

--- a/app/Index/Index_Search.cpp
+++ b/app/Index/Index_Search.cpp
@@ -1,23 +1,21 @@
 #include "../Logging/logging.h"
 #include "index.h"
-#include <array>
 #include <cstddef>
 #include <cstring>
 #include <filesystem>
-#include <fstream>
 #include <string>
 #include <utility>
 #include <vector>
 
-std::vector<PATH_ID_TYPE> Index::path_ids_from_word_id(uint64_t word_id) {
+std::vector<PATH_ID_TYPE> Index::path_ids_from_word_id(uint64_t word_id)
+{
   std::vector<PATH_ID_TYPE> path_ids;
-  if ((word_id * REVERSED_ENTRY_SIZE) + REVERSED_ENTRY_SIZE > reversed_size) {
+  if ((word_id * REVERSED_ENTRY_SIZE) + REVERSED_ENTRY_SIZE > disk_io.get_reversed_size()) {
     Log::error("Index: path_ids_from_word_id: to search word id would be at "
-               "nonexisting location. Index most likely corrupt. Exiting");
+      "nonexisting location. Index most likely corrupt. Exiting");
   }
   // load the reversed block into memory.
-  ReversedBlock *disk_reversed = reinterpret_cast<ReversedBlock *>(
-      &mmap_reversed[word_id * REVERSED_ENTRY_SIZE]);
+  ReversedBlock* disk_reversed = disk_io.get_reversed_pointer(word_id);
   for (int i = 0; i < REVERSED_PATH_LINKS_AMOUNT; ++i) {
     if (disk_reversed->ids.path[i] != 0) {
       path_ids.push_back(disk_reversed->ids.path[i]);
@@ -29,31 +27,30 @@ std::vector<PATH_ID_TYPE> Index::path_ids_from_word_id(uint64_t word_id) {
     return path_ids;
   }
   if ((disk_reversed->ids.additional[0] * ADDITIONAL_ENTRY_SIZE) >
-      additional_size) {
+    disk_io.get_additional_size()) {
     Log::error("Index: path_ids_from_word_id: Additional block would be at non "
-               "existing location. Exiting");
+      "existing location. Exiting");
   }
-  AdditionalBlock *disk_additional = reinterpret_cast<AdditionalBlock *>(
-      &mmap_additional[(disk_reversed->ids.additional[0] - 1) *
-                       ADDITIONAL_ENTRY_SIZE]);
+  AdditionalBlock* disk_additional = disk_io.get_additional_pointer(disk_reversed->ids.additional[0]);
 
   // load the current additional block. -1 because additional IDs start at 1.
   int i = 0;
   size_t current_additional = disk_reversed->ids.additional[0];
-  while (true) { // it will break when no new additional is linked
+  while (true) {
+    // it will break when no new additional is linked
     if (i == ADDITIONAL_PATH_LINKS_AMOUNT) {
       if (disk_additional->ids.additional[0] == 0) {
         // no additionals are left.
         break;
-      } else {
+      }
+      else {
         // load the new additional block
         current_additional = disk_additional->ids.additional[0];
-        if ((current_additional * ADDITIONAL_ENTRY_SIZE) > additional_size) {
+        if ((current_additional * ADDITIONAL_ENTRY_SIZE) > disk_io.get_additional_size()) {
           Log::error("Index: path_ids_from_word_id: Additional block would be "
-                     "at non existing location. Exiting");
+            "at non existing location. Exiting");
         }
-        disk_additional = reinterpret_cast<AdditionalBlock *>(
-            &mmap_additional[(current_additional - 1) * ADDITIONAL_ENTRY_SIZE]);
+        disk_additional = disk_io.get_additional_pointer(current_additional);
         i = 0;
       }
     }
@@ -71,51 +68,48 @@ std::vector<PATH_ID_TYPE> Index::path_ids_from_word_id(uint64_t word_id) {
 
 // Searches the word list for all words in search words and returns a list of
 // path ids and the count of how many appeared. exact_match: if enabled it not
-// count words that are the same as the query but different length. e.g query:
+// count words that are the same as the query but different length. e.g. query:
 // ap and it encounters apple. If false it would count that as a match.
 // min_char_for_match will also count words if the first x chars are the same,
 // only if exact_match is false.
 std::vector<search_path_ids_count_return>
-Index::search_word_list(std::vector<std::pair<std::string, bool>> &search_words,
-                        int min_char_for_match) {
+Index::search_word_list(std::vector<std::pair<std::string, bool>>& search_words,
+                        int min_char_for_match)
+{
   std::vector<std::vector<uint64_t>> result_word_ids(
-      search_words
-          .size()); // because of exact match some words may have multiple
-                    // word ids connected. and to keep it connected to the
-                    // search words for later processing we need to do this.
+    search_words
+    .size()); // because of exact match some words may have multiple
+  // word ids connected. and to keep it connected to the
+  // search words for later processing we need to do this.
   std::vector<search_path_ids_count_return> results(search_words.size());
 
   if (!initialized || !health_status()) {
     Log::write(3, "Index is not initialized or it's not readable(e.g because a "
-                  "Transaction Execution is in progress)");
+               "Transaction Execution is in progress)");
     return results;
   }
   if (is_mapped == false) {
-    map();
+    disk_io.map(CONFIG_INDEX_PATH);
   }
 
   if (search_words.size() == 0) {
     return results;
   }
   // sort first so we can do char for char compare. This should be done already
-  // in the search function but we will do it again because this is public and
+  // in the search function, but we will do it again because this is public and
   // if not sorted it may freeze.
-  std::sort(search_words.begin(), search_words.end());
+  std::ranges::sort(search_words);
 
   // copy words_f into memory
-  std::vector<WordsFValue> words_f(26);
-  for (int i = 0; i < 26; ++i) {
-    std::memcpy(&words_f[i].bytes[0],
-                &mmap_words_f[i * (8 + WORDS_F_LOCATION_SIZE)],
-                (8 + WORDS_F_LOCATION_SIZE));
-  }
+  std::vector<WordsFValue> words_f = disk_io.get_words_f();
 
-  // local index words needs to have atleast 1 value. Is checked by LocalIndex
+
+  // local index words needs to have at least 1 value. Is checked by LocalIndex
   // add_to_disk.
   size_t on_disk_count = 0;
   size_t on_disk_id = 0;
   size_t local_word_count = 0;
-  size_t local_word_length = search_words[0].first.length();
+  uint8_t local_word_length = search_words[0].first.length();
   size_t last_match_on_disk_count = 0;
   size_t last_match_on_disk_id = 0;
 
@@ -130,27 +124,28 @@ Index::search_word_list(std::vector<std::pair<std::string, bool>> &search_words,
   // match rules.
   bool wildcard = false;
   std::pair<std::size_t, std::size_t> wildcard_match_mark(
-      0, 0); // first is count, second id.
+    0, 0); // first is count, second id.
 
   char disk_first_char = 'a';
   char local_first_char = search_words[0].first[0];
 
   // check each word on disk. if it is different first letter we will skip using
   // words_f. we will compare chars to chars until they differ. we then know if
-  // it is coming first or we are passed it and need to insert the word or we
+  // it is coming first, or we are passed it and need to insert the word, or we
   // are at the same word.
 
-  while (on_disk_count < words_size) {
+  while (on_disk_count < disk_io.get_words_size()) {
     // If the current word first char is different we use words_f to set the
     // location to the start of that char.
     if (disk_first_char < local_first_char) {
-      if (words_f[local_first_char - 'a'].location < words_size) {
+      if (words_f[local_first_char - 'a'].location < disk_io.get_words_size()) {
         Log::write(1, "Index: Search: Skipping using Words_f Table");
         on_disk_count = words_f[local_first_char - 'a'].location;
         on_disk_id = words_f[local_first_char - 'a'].id;
         disk_first_char = local_first_char;
-      } else {
-        if (words_f[local_first_char - 'a'].location == words_size) {
+      }
+      else {
+        if (words_f[local_first_char - 'a'].location == disk_io.get_words_size()) {
           // Words_f can have entries when if it is the same as words_size it
           // means there are no words for this letter and no subsequent letters
           // too
@@ -158,38 +153,32 @@ Index::search_word_list(std::vector<std::pair<std::string, bool>> &search_words,
         }
         // This should not happen. Index is corrupted.
         Log::error("Index: Search: Words_f char value is higher than words "
-                   "index size. This means the index is corrupted. Reset the "
-                   "index and report this problem.");
+          "index size. This means the index is corrupted. Reset the "
+          "index and report this problem.");
       }
     }
 
-    // read the one byte word sperator.
-    WordSeperator word_sep;
-    for (uint8_t i = 0; i < WORD_SEPARATOR_SIZE; ++i) {
-      word_sep.bytes[i] = mmap_words[on_disk_count + i];
-    }
-    WORD_SEPARATOR_TYPE word_seperator = word_sep.seperator;
+    WORD_SEPARATOR_TYPE word_seperator = disk_io.get_word_separator(on_disk_count);
     if (word_seperator <= 0) {
       // can't be 0 or lower than 0. index corrupt most likely
       Log::error("Index: Combine: Word Seperator is 0 or lower. This can not "
-                 "be. Index most likely corrupt.");
+        "be. Index most likely corrupt.");
     }
 
+    char word_first_char = disk_io.get_char_of_word(on_disk_count, 0);
     if (disk_first_char <
-        mmap_words[on_disk_count +
-                   WORD_SEPARATOR_SIZE]) { // + 1 because of the word seperator
-      disk_first_char = mmap_words[on_disk_count + WORD_SEPARATOR_SIZE];
+      word_first_char) {
+      disk_first_char = word_first_char;
     }
 
     for (int i = 0; i < word_seperator; ++i) {
-
-      // the current char on disk and local are the same.
-      if ((int)mmap_words[on_disk_count + WORD_SEPARATOR_SIZE + i] ==
-          (int)(search_words[local_word_count].first[i])) {
-
+      // If current chars are the same + word on disk length same as on local
+      // length and last char add to existing word
+      char disk_c = disk_io.get_char_of_word(on_disk_count, i);
+      char local_c = search_words[local_word_count].first[i];
+      if (disk_c == local_c) {
         // exact same length, exact match.
         if (i == local_word_length - 1 && word_seperator == local_word_length) {
-
           if (!search_words[local_word_count].second) {
             // wildcard match, exact same.
             if (i >= min_char_for_match) {
@@ -200,21 +189,24 @@ Index::search_word_list(std::vector<std::pair<std::string, bool>> &search_words,
               wildcard_match_mark.first = on_disk_count;
               wildcard_match_mark.second = on_disk_id;
             }
-          } else {
+          }
+          else {
             result_word_ids[local_word_count].push_back(on_disk_id);
             ++local_word_count;
             if (local_word_count ==
-                search_words.size()) { // if not more words to compare quit.
+              search_words.size()) {
+              // if not more words to compare quit.
               break;
             }
 
             if (search_words[local_word_count].first ==
-                search_words[local_word_count - 1].first) {
-              // If the current and next word are the same (e.g one is direct
+              search_words[local_word_count - 1].first) {
+              // If the current and next word are the same (e.g. one is direct
               // match, the other not), we will need to move on disk count back.
               on_disk_count = last_match_on_disk_count;
               on_disk_id = last_match_on_disk_id;
-            } else {
+            }
+            else {
               last_match_on_disk_count = on_disk_count;
               last_match_on_disk_id = on_disk_id;
             }
@@ -223,7 +215,7 @@ Index::search_word_list(std::vector<std::pair<std::string, bool>> &search_words,
           }
 
           on_disk_count +=
-              word_seperator + WORD_SEPARATOR_SIZE; // then the next seperator
+            word_seperator + WORD_SEPARATOR_SIZE; // then the next seperator
           ++on_disk_id;
 
           break;
@@ -245,21 +237,24 @@ Index::search_word_list(std::vector<std::pair<std::string, bool>> &search_words,
               wildcard_match_mark.second = on_disk_id;
             }
             on_disk_count +=
-                word_seperator + WORD_SEPARATOR_SIZE; // then the next seperator
+              word_seperator + WORD_SEPARATOR_SIZE; // then the next seperator
             ++on_disk_id;
-          } else {
+          }
+          else {
             ++local_word_count;
             if (local_word_count ==
-                search_words.size()) { // if not more words to compare quit.
+              search_words.size()) {
+              // if not more words to compare quit.
               break;
             }
             if (search_words[local_word_count].first ==
-                search_words[local_word_count - 1].first) {
-              // If the current and next word are the same (e.g one is direct
+              search_words[local_word_count - 1].first) {
+              // If the current and next word are the same (e.g. one is direct
               // match, the other not), we will need to move on disk count back.
               on_disk_count = last_match_on_disk_count;
               on_disk_id = last_match_on_disk_id;
-            } else {
+            }
+            else {
               last_match_on_disk_count = on_disk_count;
               last_match_on_disk_id = on_disk_id;
             }
@@ -273,16 +268,14 @@ Index::search_word_list(std::vector<std::pair<std::string, bool>> &search_words,
         // on disk word length reached, local word is bigger, skipping.
         if (i == word_seperator - 1) {
           on_disk_count +=
-              word_seperator + WORD_SEPARATOR_SIZE; // then the next seperator
+            word_seperator + WORD_SEPARATOR_SIZE; // then the next seperator
           ++on_disk_id;
           break;
         }
       }
 
       // If disk char > local char
-      if ((int)mmap_words[on_disk_count + WORD_SEPARATOR_SIZE + i] >
-          (int)(search_words[local_word_count].first[i])) {
-
+      if (disk_c > local_c) {
         ++local_word_count;
         if (wildcard) {
           // if we had a wildcard that reached his exact match or passed it we
@@ -294,17 +287,19 @@ Index::search_word_list(std::vector<std::pair<std::string, bool>> &search_words,
         }
 
         if (local_word_count ==
-            search_words.size()) { // if not more words to compare quit.
+          search_words.size()) {
+          // if not more words to compare quit.
           break;
         }
 
         if (search_words[local_word_count].first ==
-            search_words[local_word_count - 1].first) {
-          // If the current and next word are the same (e.g one is direct
+          search_words[local_word_count - 1].first) {
+          // If the current and next word are the same (e.g. one is direct
           // match, the other not), we will need to move on disk count back.
           on_disk_count = last_match_on_disk_count;
           on_disk_id = last_match_on_disk_id;
-        } else {
+        }
+        else {
           last_match_on_disk_count = on_disk_count;
           last_match_on_disk_id = on_disk_id;
         }
@@ -315,41 +310,40 @@ Index::search_word_list(std::vector<std::pair<std::string, bool>> &search_words,
       }
 
       // If disk char < local char
-      if ((int)mmap_words[on_disk_count + WORD_SEPARATOR_SIZE + i] <
-          (int)(search_words[local_word_count].first[i])) {
-
+      if (disk_c < local_c) {
         on_disk_count +=
-            word_seperator + WORD_SEPARATOR_SIZE; // then the next seperator
+          word_seperator + WORD_SEPARATOR_SIZE; // then the next seperator
         ++on_disk_id;
         break;
       }
     }
     if (local_word_count ==
-        search_words.size()) { // if not more words to compare quit.
+      search_words.size()) {
+      // if not more words to compare quit.
       break;
     }
   }
 
   // Now we need to read all reversed and additionals and put it into a list of
   // path_id count.
-  // we will later combine them but it's easier like this.
+  // we will later combine them, but it's easier like this.
 
   if (result_word_ids.size() == 0)
     return results;
   for (size_t i = 0; i < result_word_ids.size(); ++i) {
     if (result_word_ids[i].size() == 0)
       continue;
-    for (int j = 0; j < result_word_ids[i].size(); ++j) {
-      for (const int &path_id : path_ids_from_word_id(result_word_ids[i][j])) {
-        // potential future performance improvments
-        if (auto it = std::find(results[i].path_id.begin(),
-                                results[i].path_id.end(), path_id);
-            it == results[i].path_id.end()) {
+    for (size_t j = 0; j < result_word_ids[i].size(); ++j) {
+      for (const int& path_id : path_ids_from_word_id(result_word_ids[i][j])) {
+        // potential future performance improvements
+        if (auto it = std::ranges::find(results[i].path_id, path_id);
+          it == results[i].path_id.end()) {
           results[i].path_id.push_back(path_id);
           results[i].count.push_back(1);
-        } else {
+        }
+        else {
           ++results[i].count[it - results[i].path_id.begin()]; // increase count
-                                                               // of the element
+          // of the element
         }
       }
     }
@@ -357,17 +351,18 @@ Index::search_word_list(std::vector<std::pair<std::string, bool>> &search_words,
   return results;
 }
 
-// return a unordered map of ID and path string.
+// return am unordered map of ID and path string.
 std::unordered_map<PATH_ID_TYPE, std::string>
-Index::id_to_path_string(std::vector<search_path_ids_return> path_ids) {
+Index::id_to_path_string(std::vector<search_path_ids_return>& path_ids)
+{
   std::unordered_map<PATH_ID_TYPE, std::string> results;
   if (!initialized || !health_status()) {
     Log::write(3, "Index is not initialized or it's not readable(e.g because a "
-                  "Transaction Execution is in progress)");
+               "Transaction Execution is in progress)");
     return results;
   }
   if (is_mapped == false) {
-    map();
+    disk_io.map(CONFIG_INDEX_PATH);
   }
 
   if (path_ids.size() == 0) {
@@ -379,31 +374,31 @@ Index::id_to_path_string(std::vector<search_path_ids_return> path_ids) {
   std::sort(sorted_path_ids.begin(), sorted_path_ids.end());
   uint64_t path_count = 1; // on-disk path ids are indexed from 1.
   uint64_t local_count = 0;
-  if (paths_size < 2) { // shouldn't happen. invalid. index corrupt.
+  if (disk_io.get_paths_size() < 2) {
+    // shouldn't happen. invalid. index corrupt.
     Log::error("Index: Search: id_to_path_string: Error. Paths index invalid. "
-               "Index most likely corrupt.");
+      "Index most likely corrupt.");
   }
-  for (size_t i = 0; i < paths_size;) {
-    PathOffset *path_length = reinterpret_cast<PathOffset *>(
-        &mmap_paths[i]); // load the length offset
+  for (size_t i = 0; i < disk_io.get_paths_size();) {
+    uint16_t path_length = disk_io.get_path_separator(i);
     i += 2;
 
     if (path_count == sorted_path_ids[local_count].path_id) {
-      if (paths_size < i + path_length->offset) { // shouldn't happen.
-                                                  // invalid. index corrupt.
+      if (disk_io.get_paths_size() < i + path_length) {
+        // shouldn't happen.
+        // invalid. index corrupt.
         Log::error(
-            "Index: Search: id_to_path_string: Error. Paths index invalid. "
-            "Index most likely corrupt.");
+          "Index: Search: id_to_path_string: Error. Paths index invalid. "
+          "Index most likely corrupt.");
       }
-      results[sorted_path_ids[local_count].path_id] =
-          std::string(&mmap_paths[i], path_length->offset);
+      results[sorted_path_ids[local_count].path_id] = disk_io.get_path(i, path_length);
       ++local_count;
     }
     ++path_count;
     if (local_count == path_ids.size()) {
       break;
     }
-    i += path_length->offset;
+    i += path_length;
   }
   return results;
 }

--- a/app/Index/Index_Transaction.cpp
+++ b/app/Index/Index_Transaction.cpp
@@ -297,7 +297,7 @@ int Index::execute_transactions()
       0) {
       // sync only if it was not a move operation or 5000 move
       // operations happend
-      if (disk_io.sync_all() == 1) {
+      if (!disk_io.sync_all()) {
         Log::error(
           "Error when syncing indexes to disk. Exiting Program to save "
           "data. Please restart to see if the issue continues.");

--- a/app/Index/Index_Transaction.cpp
+++ b/app/Index/Index_Transaction.cpp
@@ -7,9 +7,10 @@
 #include <fstream>
 #include <string>
 
-void Index::write_to_transaction(std::vector<Transaction> &transactions,
-                                 mio::mmap_sink &mmap_transactions,
-                                 size_t &transaction_file_location) {
+void Index::write_to_transaction(std::vector<Transaction>& transactions,
+                                 mio::mmap_sink& mmap_transactions,
+                                 size_t& transaction_file_location)
+{
   std::error_code ec;
   for (size_t i = 0; i < transactions.size(); ++i) {
     // copy the header first. Then check the operation type and then copy
@@ -18,14 +19,16 @@ void Index::write_to_transaction(std::vector<Transaction> &transactions,
                 &transactions[i].header.bytes[0], 27);
     transaction_file_location += 27;
     if (transactions[i].header.operation_type != 2 &&
-        transactions[i].header.operation_type != 3) { // resize or backup
+      transactions[i].header.operation_type != 3) {
+      // resize or backup
       if (transactions[i].header.operation_type == 0) {
         // For move operations content is 8 bytes long as a uint64_t to
         // represent the byte shift. content length is used for end pos.
         std::memcpy(&mmap_transactions[transaction_file_location],
                     &transactions[i].content[0], 8);
         transaction_file_location += 8;
-      } else {
+      }
+      else {
         std::memcpy(&mmap_transactions[transaction_file_location],
                     &transactions[i].content[0],
                     transactions[i].header.content_length);
@@ -37,9 +40,10 @@ void Index::write_to_transaction(std::vector<Transaction> &transactions,
     Log::error("Index: Write to Transaction Failed. Exiting");
 }
 
-int Index::write_transaction_file(const std::filesystem::path &transaction_path,
-                                  std::vector<Transaction> &move_transactions,
-                                  std::vector<Transaction> &transactions) {
+int Index::write_transaction_file(const std::filesystem::path& transaction_path,
+                                  std::vector<Transaction>& move_transactions,
+                                  std::vector<Transaction>& transactions)
+{
   // writes the Transactionf file and does some extra checks
   std::error_code ec;
 
@@ -47,22 +51,22 @@ int Index::write_transaction_file(const std::filesystem::path &transaction_path,
   // file.
   std::filesystem::remove_all(CONFIG_INDEX_PATH / "transaction" / "backups");
   if (!std::filesystem::is_directory(CONFIG_INDEX_PATH / "transaction" /
-                                     "backups")) {
+    "backups")) {
     Log::write(1,
                "Index: intitialize: creating transactions backups directory.");
     std::filesystem::create_directories(CONFIG_INDEX_PATH / "transaction" /
-                                        "backups");
+      "backups");
   }
 
   size_t recalculated_size = 0;
-  for (const auto &tx : transactions) {
+  for (const auto& tx : transactions) {
     recalculated_size += 27; // Header size
     if (tx.header.operation_type != 2 && tx.header.operation_type != 3) {
       recalculated_size += tx.header.content_length;
     }
   }
   // only move and backup transactions
-  for (const auto &tx : move_transactions) {
+  for (const auto& tx : move_transactions) {
     recalculated_size += 27; // Header size
     if (tx.header.operation_type != 3) {
       recalculated_size += 8; // Move operations need 8 bytes
@@ -98,7 +102,8 @@ int Index::write_transaction_file(const std::filesystem::path &transaction_path,
   return 0;
 }
 
-int Index::execute_transactions() {
+int Index::execute_transactions()
+{
   Log::write(2, "Index: Transaction: Beginning execution of transaction list");
   std::error_code ec;
   size_t transaction_current_id = 0;
@@ -106,8 +111,8 @@ int Index::execute_transactions() {
   size_t transaction_current_location = 0;
   mio::mmap_sink mmap_transactions;
   mmap_transactions = mio::make_mmap_sink(
-      (CONFIG_INDEX_PATH / "transaction" / "transaction.list").string(), 0,
-      mio::map_entire_file, ec);
+    (CONFIG_INDEX_PATH / "transaction" / "transaction.list").string(), 0,
+    mio::map_entire_file, ec);
   /*Log::write(1, "Index: Transaction: Detected " +
                     std::to_string(
                         std::filesystem::file_size(CONFIG_INDEX_PATH /
@@ -119,30 +124,31 @@ int Index::execute_transactions() {
   }
 
   while (transaction_current_location + 27 <
-         std::filesystem::file_size(
-             CONFIG_INDEX_PATH / "transaction" /
-             "transaction.list")) { // if we can read current position + a whole
-                                    // trasactionheader
-    TransactionHeader *current_header = reinterpret_cast<TransactionHeader *>(
-        &mmap_transactions
-            [transaction_current_location]); // get the first
-                                             // transaction.
-                                             // In execute_transactions, right
-                                             // after loading the header
+    std::filesystem::file_size(
+      CONFIG_INDEX_PATH / "transaction" /
+      "transaction.list")) {
+    // if we can read current position + a whole
+    // trasactionheader
+    TransactionHeader* current_header = reinterpret_cast<TransactionHeader*>(
+      &mmap_transactions
+      [transaction_current_location]); // get the first
+    // transaction.
+    // In execute_transactions, right
+    // after loading the header
     Log::write(
-        1, "Transaction header dump - status: " +
-               std::to_string(current_header->status) +
-               ", index_type: " + std::to_string(current_header->index_type) +
-               ", location: " + std::to_string(current_header->location) +
-               ", backup_id: " + std::to_string(current_header->backup_id) +
-               ", operation_type: " +
-               std::to_string(current_header->operation_type) +
-               ", content_length: " +
-               std::to_string(current_header->content_length));
+      1, "Transaction header dump - status: " +
+      std::to_string(current_header->status) +
+      ", index_type: " + std::to_string(current_header->index_type) +
+      ", location: " + std::to_string(current_header->location) +
+      ", backup_id: " + std::to_string(current_header->backup_id) +
+      ", operation_type: " +
+      std::to_string(current_header->operation_type) +
+      ", content_length: " +
+      std::to_string(current_header->content_length));
     if (current_header->status == 2) {
       Log::write(
-          1, "Index: Transaction: Skipping already completed transaction #" +
-                 std::to_string(transaction_current_id));
+        1, "Index: Transaction: Skipping already completed transaction #" +
+        std::to_string(transaction_current_id));
       // skip as already complete
       ++transaction_current_id;
       if (current_header->operation_type == 1) {
@@ -158,226 +164,154 @@ int Index::execute_transactions() {
       // check if need to restore from backup
       if (current_header->backup_id != 0) {
         Log::write(1, "Index: Transaction: Processing backup ID " +
-                          std::to_string(current_header->backup_id) +
-                          " for transaction #" +
-                          std::to_string(transaction_current_id));
+                   std::to_string(current_header->backup_id) +
+                   " for transaction #" +
+                   std::to_string(transaction_current_id));
         std::string backup_file_name =
-            std::to_string(current_header->backup_id) + ".backup";
+          std::to_string(current_header->backup_id) + ".backup";
         if (current_header->operation_type ==
-            3) { // If it is a backup creation we just delete the current backup
-                 // file if it exists and then continue.
+          3) {
+          // If it is a backup creation we just delete the current backup
+          // file if it exists and then continue.
           std::filesystem::remove(CONFIG_INDEX_PATH / "transaction" /
-                                  "backups" / backup_file_name);
-        } else {
+            "backups" / backup_file_name);
+        }
+        else {
           if (current_header->content_length !=
-              std::filesystem::file_size(CONFIG_INDEX_PATH / "transaction" /
-                                         "backups" / backup_file_name)) {
+            std::filesystem::file_size(CONFIG_INDEX_PATH / "transaction" /
+              "backups" / backup_file_name)) {
             Log::error("Transaction: backup file corrupt. Can not restore from "
-                       "backup. Index potentially corrupt. Exiting. This "
-                       "should never happen.");
+              "backup. Index potentially corrupt. Exiting. This "
+              "should never happen.");
           }
           mio::mmap_sink mmap_backup;
           mmap_backup = mio::make_mmap_sink(
-              (CONFIG_INDEX_PATH / "transaction" / "backups" / backup_file_name)
-                  .string(),
-              0, mio::map_entire_file, ec);
+            (CONFIG_INDEX_PATH / "transaction" / "backups" / backup_file_name)
+            .string(),
+            0, mio::map_entire_file, ec);
           // restore from backup. overwrite then continue.
-          if (current_header->index_type == 1) {
-            // words index
-            std::memcpy(&mmap_words[current_header->location], &mmap_backup[0],
-                        current_header->content_length);
-          }
-          if (current_header->index_type == 3) {
-            // reversed index.
-            std::memcpy(&mmap_reversed[current_header->location],
-                        &mmap_backup[0], current_header->content_length);
-          }
+          disk_io.copy_to_index(current_header->index_type, mmap_backup, current_header->location,
+                                0, current_header->content_length);
         }
       }
     }
     if (current_header->status == 0 && transaction_current_id == 0) {
       // did not start yet. transaction file not successfully writen. Abort
       Log::write(
-          2, "Index: Transaction: transaction list appears to have not "
-             "finished creating. Deleting only incomplete Transaction List.");
+        2, "Index: Transaction: transaction list appears to have not "
+        "finished creating. Deleting only incomplete Transaction List.");
       break;
     }
     // continue executing transaction.
     Log::write(1, "Index: Transaction: Executing transaction #" +
-                      std::to_string(transaction_current_id) + " type=" +
-                      std::to_string(current_header->operation_type) +
-                      " index=" + std::to_string(current_header->index_type));
+               std::to_string(transaction_current_id) + " type=" +
+               std::to_string(current_header->operation_type) +
+               " index=" + std::to_string(current_header->index_type));
 
-    if (current_header->operation_type == 0) { // MOVE
+    if (current_header->operation_type == 0) {
+      // MOVE
       current_header->status = 1;
       mmap_transactions.sync(ec);
       uint64_t shift_amount = 0;
       memcpy(&shift_amount,
              &mmap_transactions[transaction_current_location + 27], 8);
-      std::memmove(
-          current_header->index_type == 0
-              ? &mmap_paths[current_header->location + shift_amount]
-              : (current_header->index_type == 1
-                     ? &mmap_words[current_header->location + shift_amount]
-                     : (current_header->index_type == 2
-                            ? &mmap_words_f[current_header->location +
-                                            shift_amount]
-                            : (current_header->index_type == 3
-                                   ? &mmap_reversed[current_header->location +
-                                                    shift_amount]
-                                   : (current_header->index_type == 4
-                                          ? &mmap_additional[current_header
-                                                                 ->location +
-                                                             shift_amount]
-                                          : &mmap_paths_count[current_header
-                                                                  ->location +
-                                                              shift_amount])))),
-          current_header->index_type == 0
-              ? &mmap_paths[current_header->location]
-              : (current_header->index_type == 1
-                     ? &mmap_words[current_header->location]
-                     : (current_header->index_type == 2
-                            ? &mmap_words_f[current_header->location]
-                            : (current_header->index_type == 3
-                                   ? &mmap_reversed[current_header->location]
-                                   : (current_header->index_type == 4
-                                          ? &mmap_additional[current_header
-                                                                 ->location]
-                                          : &mmap_paths_count
-                                                [current_header->location])))),
-          current_header->content_length);
+      disk_io.shift_data(current_header->index_type, current_header->location + shift_amount,
+                         current_header->location, current_header->content_length);
       Log::write(1, "Index: Transaction: Move operation completed for index " +
-                        std::to_string(current_header->index_type) +
-                        " at location " +
-                        std::to_string(current_header->location));
-    } else if (current_header->operation_type == 1) { // WRITE
+                 std::to_string(current_header->index_type) +
+                 " at location " +
+                 std::to_string(current_header->location));
+    }
+    else if (current_header->operation_type == 1) {
+      // WRITE
       if (transaction_current_write_sync_batch == 0 ||
-          transaction_current_write_sync_batch > 5000) {
+        transaction_current_write_sync_batch > 5000) {
         current_header->status = 1;
         mmap_transactions.sync(ec);
         transaction_current_write_sync_batch = 1;
       }
-      std::memcpy(
-          current_header->index_type == 0
-              ? &mmap_paths[current_header->location]
-              : (current_header->index_type == 1
-                     ? &mmap_words[current_header->location]
-                     : (current_header->index_type == 2
-                            ? &mmap_words_f[current_header->location]
-                            : (current_header->index_type == 3
-                                   ? &mmap_reversed[current_header->location]
-                                   : (current_header->index_type == 4
-                                          ? &mmap_additional[current_header
-                                                                 ->location]
-                                          : &mmap_paths_count
-                                                [current_header->location])))),
-          &mmap_transactions[transaction_current_location + 27],
-          current_header->content_length);
+      disk_io.copy_to_index(current_header->index_type, mmap_transactions, current_header->location,
+                            transaction_current_location + 27, current_header->content_length);
       Log::write(1, "Index: Transaction: Write operation completed for index " +
-                        std::to_string(current_header->index_type) +
-                        " at location " +
-                        std::to_string(current_header->location));
+                 std::to_string(current_header->index_type) +
+                 " at location " +
+                 std::to_string(current_header->location));
       ++transaction_current_write_sync_batch;
-    } else if (current_header->operation_type == 2) { // RESIZE
+    }
+    else if (current_header->operation_type == 2) {
+      // RESIZE
       current_header->status = 1;
       mmap_transactions.sync(ec);
-      unmap();
+      disk_io.unmap();
       resize(current_header->index_type == 0
-                 ? CONFIG_INDEX_PATH / "paths.index"
-                 : (current_header->index_type == 1
-                        ? CONFIG_INDEX_PATH / "words.index"
-                        : (current_header->index_type == 2
-                               ? CONFIG_INDEX_PATH / "words_f.index"
-                               : (current_header->index_type == 3
-                                      ? CONFIG_INDEX_PATH / "reversed.index"
-                                      : (current_header->index_type == 4
-                                             ? CONFIG_INDEX_PATH /
-                                                   "additional.index"
-                                             : CONFIG_INDEX_PATH /
-                                                   "paths_count.index")))),
+               ? CONFIG_INDEX_PATH / "paths.index"
+               : (current_header->index_type == 1
+                    ? CONFIG_INDEX_PATH / "words.index"
+                    : (current_header->index_type == 2
+                         ? CONFIG_INDEX_PATH / "words_f.index"
+                         : (current_header->index_type == 3
+                              ? CONFIG_INDEX_PATH / "reversed.index"
+                              : (current_header->index_type == 4
+                                   ? CONFIG_INDEX_PATH /
+                                   "additional.index"
+                                   : CONFIG_INDEX_PATH /
+                                   "paths_count.index")))),
              current_header->content_length);
-      switch (current_header->index_type) {
-      case 0:
-        paths_size = current_header->content_length;
-        break;
-      case 1:
-        words_size = current_header->content_length;
-        break;
-      case 2:
-        words_f_size = current_header->content_length;
-        break;
-      case 3:
-        reversed_size = current_header->content_length;
-        break;
-      case 4:
-        additional_size = current_header->content_length;
-        break;
-      default:
-        paths_count_size = current_header->content_length;
-        break;
-      }
-      map();
+      disk_io.map(CONFIG_INDEX_PATH); // mapping handles size updates internally al
       Log::write(
-          1, "Index: Transaction: Resize operation completed for index " +
-                 std::to_string(current_header->index_type) + " and size: " +
-                 std::to_string(current_header->content_length));
-    } else if (current_header->operation_type == 3) { // CREATE A BACKUP
+        1, "Index: Transaction: Resize operation completed for index " +
+        std::to_string(current_header->index_type) + " and size: " +
+        std::to_string(current_header->content_length));
+    }
+    else if (current_header->operation_type == 3) {
+      // CREATE A BACKUP
       current_header->status = 1;
       mmap_transactions.sync(ec);
       std::string backup_file_name =
-          std::to_string(current_header->backup_id) + ".backup";
-      std::ofstream{CONFIG_INDEX_PATH / "transaction" / "backups" /
-                    backup_file_name};
+        std::to_string(current_header->backup_id) + ".backup";
+      std::ofstream{
+        CONFIG_INDEX_PATH / "transaction" / "backups" /
+        backup_file_name
+      };
       resize(CONFIG_INDEX_PATH / "transaction" / "backups" / backup_file_name,
              current_header->content_length);
       mio::mmap_sink mmap_backup;
       mmap_backup = mio::make_mmap_sink(
-          (CONFIG_INDEX_PATH / "transaction" / "backups" / backup_file_name)
-              .string(),
-          0, mio::map_entire_file, ec);
-      std::memcpy(
-          &mmap_backup[0],
-          current_header->index_type == 0
-              ? &mmap_paths[current_header->location]
-              : (current_header->index_type == 1
-                     ? &mmap_words[current_header->location]
-                     : (current_header->index_type == 2
-                            ? &mmap_words_f[current_header->location]
-                            : (current_header->index_type == 3
-                                   ? &mmap_reversed[current_header->location]
-                                   : (current_header->index_type == 4
-                                          ? &mmap_additional[current_header
-                                                                 ->location]
-                                          : &mmap_paths_count
-                                                [current_header->location])))),
-          current_header->content_length);
+        (CONFIG_INDEX_PATH / "transaction" / "backups" / backup_file_name)
+        .string(),
+        0, mio::map_entire_file, ec);
+      disk_io.copy_from_index(current_header->index_type, mmap_backup, 0, current_header->location,
+                              current_header->content_length);
       mmap_backup.sync(ec);
       mmap_backup.unmap();
       Log::write(
-          1, "Index: Transaction: Backup operation completed for index " +
-                 std::to_string(current_header->index_type) + " at location " +
-                 std::to_string(current_header->location));
+        1, "Index: Transaction: Backup operation completed for index " +
+        std::to_string(current_header->index_type) + " at location " +
+        std::to_string(current_header->location));
     }
 
     // snyc before we mark as done.
     if (current_header->operation_type != 1 ||
-        transaction_current_write_sync_batch > 5000 ||
-        transaction_current_write_sync_batch ==
-            0) { // sync only if it was not a move operation or 5000 move
-                 // operations happend
-      if (sync_all() == 1) {
+      transaction_current_write_sync_batch > 5000 ||
+      transaction_current_write_sync_batch ==
+      0) {
+      // sync only if it was not a move operation or 5000 move
+      // operations happend
+      if (disk_io.sync_all() == 1) {
         Log::error(
-            "Error when syncing indexes to disk. Exiting Program to save "
-            "data. Please restart to see if the issue continues.");
-      } else {
+          "Error when syncing indexes to disk. Exiting Program to save "
+          "data. Please restart to see if the issue continues.");
+      }
+      else {
         Log::write(
-            1, "Index: Transaction: Successfully synced index changes to disk");
+          1, "Index: Transaction: Successfully synced index changes to disk");
       }
       transaction_current_write_sync_batch = 0;
     }
 
     // mark current transaction as in completed and sync to disk.
-    if (current_header->operation_type != 1) { // only sync if it is not a move
+    if (current_header->operation_type != 1) {
+      // only sync if it is not a move
       current_header->status = 2;
       mmap_transactions.sync(ec);
     }
@@ -390,20 +324,20 @@ int Index::execute_transactions() {
     }
     transaction_current_location += 27;
     Log::write(1, "Index: Transaction: Completed transaction #" +
-                      std::to_string(transaction_current_id - 1));
+               std::to_string(transaction_current_id - 1));
   }
   Log::write(2, "Index: Transaction: Successfully completed " +
-                    std::to_string(transaction_current_id) + " transactions");
+             std::to_string(transaction_current_id) + " transactions");
 
   Log::write(2,
              "Index: Transaction: Cleaning up transaction files and backups");
 
   std::filesystem::remove(CONFIG_INDEX_PATH / "transaction" /
-                          "transaction.list");
+    "transaction.list");
   // removing all backups because they are not needed anymore.
   std::filesystem::remove_all(CONFIG_INDEX_PATH / "transaction" / "backups");
   std::filesystem::create_directories(CONFIG_INDEX_PATH / "transaction" /
-                                      "backups");
+    "backups");
   Log::write(2, "Index: Transaction: Execution finished.");
   return 0;
 }

--- a/app/Index/Index_Transaction.cpp
+++ b/app/Index/Index_Transaction.cpp
@@ -257,7 +257,7 @@ int Index::execute_transactions()
                                    : CONFIG_INDEX_PATH /
                                    "paths_count.index")))),
              current_header->content_length);
-      disk_io.map(CONFIG_INDEX_PATH); // mapping handles size updates internally al
+      disk_io.map(CONFIG_INDEX_PATH); // mapping handles size updates internally already
       Log::write(
         1, "Index: Transaction: Resize operation completed for index " +
         std::to_string(current_header->index_type) + " and size: " +

--- a/app/Index/index.h
+++ b/app/Index/index.h
@@ -58,7 +58,8 @@ private:
     size_t get_additional_size() const;
     bool get_mapped() const;
     bool get_locked() const;
-  AdditionalBlock* get_additional_pointer(const ADDITIONAL_ID_TYPE id);
+    AdditionalBlock* get_additional_pointer(const ADDITIONAL_ID_TYPE id);
+    ReversedBlock* get_reversed_pointer(const size_t id);
   };
 
 private:

--- a/app/Index/index.h
+++ b/app/Index/index.h
@@ -65,6 +65,7 @@ private:
     std::vector<WordsFValue> get_words_f() const;
     uint16_t get_path_separator(size_t start_pos) const;
     std::string get_path(size_t start_pos, uint16_t length) const;
+    uint32_t get_path_count(size_t path_id) const;
   };
 
 private:

--- a/app/Index/index.h
+++ b/app/Index/index.h
@@ -58,6 +58,7 @@ private:
     size_t get_additional_size() const;
     bool get_mapped() const;
     bool get_locked() const;
+  AdditionalBlock* get_additional_pointer(const ADDITIONAL_ID_TYPE id);
   };
 
 private:

--- a/app/Index/index.h
+++ b/app/Index/index.h
@@ -38,6 +38,7 @@ private:
 
     bool map_file(mio::mmap_sink& target_mmap, size_t& target_size, const std::string& source_path);
     bool sync_file(mio::mmap_sink& target_mmap);
+    mio::mmap_sink* get_target_mmap(uint8_t target_index);
 
   public:
     DiskIO();
@@ -78,6 +79,12 @@ private:
     void set_words_f(std::vector<WordsFValue>& words_f);
     void set_additional(const AdditionalBlock& additional_block, size_t additional_id);
     void set_reversed(const ReversedBlock& reversed_block, size_t word_id);
+    void copy_to_index(uint8_t target_index, mio::mmap_sink& source, size_t target_pos, size_t source_pos,
+                       size_t length);
+    void shift_data(uint8_t target_index, size_t target_pos, size_t source_pos,
+                    size_t length);
+    void copy_from_index(uint8_t source_index, mio::mmap_sink& target, size_t target_pos, size_t source_pos,
+                         size_t length);
   };
 
 private:

--- a/app/Index/index.h
+++ b/app/Index/index.h
@@ -13,8 +13,54 @@
 #include <vector>
 
 // Index/Index.cpp
-class Index {
+class Index
+{
 private:
+  class DiskIO
+  {
+  private:
+    mio::mmap_sink mmap_paths;
+    mio::mmap_sink mmap_paths_count;
+    mio::mmap_sink mmap_words;
+    mio::mmap_sink mmap_words_f;
+    mio::mmap_sink mmap_reversed;
+    mio::mmap_sink mmap_additional;
+    size_t paths_size;
+    size_t paths_count_size;
+    size_t words_size;
+    size_t words_f_size;
+    size_t reversed_size;
+    size_t additional_size;
+    bool additional_mapped;
+
+    bool is_mapped;
+    bool is_locked;
+
+    bool map_file(mio::mmap_sink& target_mmap, size_t& target_size, const std::string& source_path);
+
+  public:
+    DiskIO();
+
+    bool map(const std::filesystem::path& index_path);
+    // maps the index files.
+    // returns true if successful , false if not
+    bool unmap();
+    // unmaps the index files.
+    // returns true if successful , false if not
+
+
+    // getters
+    size_t get_paths_size();
+    size_t get_paths_count_size();
+    size_t get_words_size();
+    size_t get_words_f_size();
+    size_t get_reversed_size();
+    size_t get_additional_size();
+  };
+
+private:
+  static DiskIO disk_io;
+
   static bool is_config_loaded;
   static bool initialized;
   static bool readonly_initialized;
@@ -53,51 +99,51 @@ private:
   static int unmap();
   static void resize(const std::filesystem::path path_to_resize,
                      const size_t size);
-  static int add_new(index_combine_data &index_to_add);
-  static void add_reversed_to_word(index_combine_data &index_to_add,
-                                   uint64_t &on_disk_count,
-                                   std::vector<Transaction> &transactions,
-                                   size_t &additional_new_needed_size,
-                                   size_t &reversed_new_needed_size,
-                                   uint64_t &on_disk_id,
-                                   const size_t &local_word_count,
-                                   PathsMapping &paths_mapping);
-  static void add_new_word(index_combine_data &index_to_add,
-                           uint64_t &on_disk_count,
-                           std::vector<Transaction> &transactions,
-                           std::vector<Insertion> &words_insertions,
-                           std::vector<Insertion> &reversed_insertions,
-                           size_t &additional_new_needed_size,
-                           size_t &words_new_needed_size,
-                           size_t &reversed_new_needed_size,
-                           uint64_t &on_disk_id, const size_t &local_word_count,
-                           PathsMapping &paths_mapping);
+  static int add_new(index_combine_data& index_to_add);
+  static void add_reversed_to_word(index_combine_data& index_to_add,
+                                   uint64_t& on_disk_count,
+                                   std::vector<Transaction>& transactions,
+                                   size_t& additional_new_needed_size,
+                                   size_t& reversed_new_needed_size,
+                                   uint64_t& on_disk_id,
+                                   const size_t& local_word_count,
+                                   PathsMapping& paths_mapping);
+  static void add_new_word(index_combine_data& index_to_add,
+                           uint64_t& on_disk_count,
+                           std::vector<Transaction>& transactions,
+                           std::vector<Insertion>& words_insertions,
+                           std::vector<Insertion>& reversed_insertions,
+                           size_t& additional_new_needed_size,
+                           size_t& words_new_needed_size,
+                           size_t& reversed_new_needed_size,
+                           uint64_t& on_disk_id, const size_t& local_word_count,
+                           PathsMapping& paths_mapping);
   static void insertion_to_transactions(
-      std::vector<Transaction> &transactions,
-      std::vector<Transaction> &move_transactions,
-      std::vector<Insertion> &to_insertions,
-      int index_type); // index_type: 1 = words, 3 = reversed.
-  static void write_to_transaction(std::vector<Transaction> &transactions,
-                                   mio::mmap_sink &mmap_transactions,
-                                   size_t &transaction_file_location);
-  static int merge(index_combine_data &index_to_add);
+    std::vector<Transaction>& transactions,
+    std::vector<Transaction>& move_transactions,
+    std::vector<Insertion>& to_insertions,
+    int index_type); // index_type: 1 = words, 3 = reversed.
+  static void write_to_transaction(std::vector<Transaction>& transactions,
+                                   mio::mmap_sink& mmap_transactions,
+                                   size_t& transaction_file_location);
+  static int merge(index_combine_data& index_to_add);
   static int execute_transactions();
   static std::vector<PATH_ID_TYPE> path_ids_from_word_id(uint64_t word_id);
   static void lock_update_sizes();
   static int
-  write_transaction_file(const std::filesystem::path &transaction_path,
-                         std::vector<Transaction> &move_transactions,
-                         std::vector<Transaction> &transactions);
+  write_transaction_file(const std::filesystem::path& transaction_path,
+                         std::vector<Transaction>& move_transactions,
+                         std::vector<Transaction>& transactions);
 
 public:
-  static void save_config(const std::filesystem::path &index_path,
+  static void save_config(const std::filesystem::path& index_path,
                           const uint16_t lock_aquisition_timeout);
   static bool is_index_mapped();
   static int initialize();
   static int uninitialize();
-  static int add(index_combine_data &index_to_add);
+  static int add(index_combine_data& index_to_add);
   static std::vector<search_path_ids_count_return>
-  search_word_list(std::vector<std::pair<std::string, bool>> &search_words,
+  search_word_list(std::vector<std::pair<std::string, bool>>& search_words,
                    int min_char_for_match);
   static std::unordered_map<PATH_ID_TYPE, std::string>
   id_to_path_string(std::vector<search_path_ids_return> path_ids);

--- a/app/Index/index.h
+++ b/app/Index/index.h
@@ -15,29 +15,27 @@
 // Index/Index.cpp
 class Index
 {
-private:
   class DiskIO
   {
-  private:
     mio::mmap_sink mmap_paths;
     mio::mmap_sink mmap_paths_count;
     mio::mmap_sink mmap_words;
     mio::mmap_sink mmap_words_f;
     mio::mmap_sink mmap_reversed;
     mio::mmap_sink mmap_additional;
-    size_t paths_size;
-    size_t paths_count_size;
-    size_t words_size;
-    size_t words_f_size;
-    size_t reversed_size;
-    size_t additional_size;
-    bool additional_mapped;
+    size_t paths_size = 0;
+    size_t paths_count_size = 0;
+    size_t words_size = 0;
+    size_t words_f_size = 0;
+    size_t reversed_size = 0;
+    size_t additional_size = 0;
+    bool additional_mapped = false;
 
-    bool is_mapped;
-    bool is_locked;
+    bool is_mapped = false;
+    bool is_locked = false;
 
     bool map_file(mio::mmap_sink& target_mmap, size_t& target_size, const std::string& source_path);
-    bool sync_file(mio::mmap_sink& target_mmap);
+    bool sync_file(mio::mmap_sink& target_mmap) const;
     mio::mmap_sink* get_target_mmap(uint8_t target_index);
 
   public:
@@ -87,7 +85,6 @@ private:
                          size_t length);
   };
 
-private:
   static DiskIO disk_io;
 
   static bool is_config_loaded;
@@ -110,7 +107,6 @@ private:
   static std::filesystem::path CONFIG_INDEX_PATH;
   static uint16_t CONFIG_LOCK_ACQUISITION_TIMEOUT;
 
-private:
   static void check_files();
   static void resize(const std::filesystem::path path_to_resize,
                      const size_t size);

--- a/app/Index/index.h
+++ b/app/Index/index.h
@@ -64,7 +64,7 @@ private:
     AdditionalBlock* get_additional_pointer(const ADDITIONAL_ID_TYPE id);
     ReversedBlock* get_reversed_pointer(const size_t id);
     WORD_SEPARATOR_TYPE get_word_separator(const size_t start_pos) const;
-    char get_char_of_word(size_t word_start_pos, int char_pos) const;
+    char get_char_of_word(size_t word_start_pos, uint16_t char_pos) const;
     std::vector<WordsFValue> get_words_f() const;
     uint16_t get_path_separator(size_t start_pos) const;
     std::string get_path(size_t start_pos, uint16_t length) const;

--- a/app/Index/index.h
+++ b/app/Index/index.h
@@ -62,6 +62,9 @@ private:
     ReversedBlock* get_reversed_pointer(const size_t id);
     WORD_SEPARATOR_TYPE get_word_separator(const size_t start_pos) const;
     char get_char_of_word(size_t word_start_pos, int char_pos) const;
+    std::vector<WordsFValue> get_words_f() const;
+    uint16_t get_path_separator(size_t start_pos) const;
+    std::string get_path(size_t start_pos, uint16_t length) const;
   };
 
 private:

--- a/app/Index/index.h
+++ b/app/Index/index.h
@@ -110,6 +110,8 @@ private:
   static void resize(const std::filesystem::path path_to_resize,
                      const size_t size);
   static int add_new(index_combine_data& index_to_add);
+  static std::string generate_new_additionals(index_combine_data& index_to_add, const size_t& local_word_count,
+                                              PathsMapping& paths_mapping, uint32_t& current_additional);
   static void add_reversed_to_word(index_combine_data& index_to_add,
                                    uint64_t& on_disk_count,
                                    std::vector<Transaction>& transactions,

--- a/app/Index/index.h
+++ b/app/Index/index.h
@@ -95,7 +95,6 @@ private:
 
 private:
   static void check_files();
-  static int sync_all();
   static void resize(const std::filesystem::path path_to_resize,
                      const size_t size);
   static int add_new(index_combine_data& index_to_add);

--- a/app/Index/index.h
+++ b/app/Index/index.h
@@ -60,6 +60,8 @@ private:
     bool get_locked() const;
     AdditionalBlock* get_additional_pointer(const ADDITIONAL_ID_TYPE id);
     ReversedBlock* get_reversed_pointer(const size_t id);
+    WORD_SEPARATOR_TYPE get_word_separator(const size_t start_pos) const;
+    char get_char_of_word(size_t word_start_pos, int char_pos) const;
   };
 
 private:

--- a/app/Index/index.h
+++ b/app/Index/index.h
@@ -50,12 +50,14 @@ private:
 
 
     // getters
-    size_t get_paths_size();
-    size_t get_paths_count_size();
-    size_t get_words_size();
-    size_t get_words_f_size();
-    size_t get_reversed_size();
-    size_t get_additional_size();
+    size_t get_paths_size() const;
+    size_t get_paths_count_size() const;
+    size_t get_words_size() const;
+    size_t get_words_f_size() const;
+    size_t get_reversed_size() const;
+    size_t get_additional_size() const;
+    bool get_mapped() const;
+    bool get_locked() const;
   };
 
 private:

--- a/app/Index/index.h
+++ b/app/Index/index.h
@@ -68,6 +68,16 @@ private:
     uint16_t get_path_separator(size_t start_pos) const;
     std::string get_path(size_t start_pos, uint16_t length) const;
     uint32_t get_path_count(size_t path_id) const;
+
+    // setters
+    void set_path_separator(size_t start_pos, const uint16_t separator);
+    void set_path(size_t start_pos, const std::string& path, uint16_t length);
+    void set_path_count(const size_t path_id, const uint32_t path_count);
+    void set_word_separator(const size_t start_pos, const WORD_SEPARATOR_TYPE separator);
+    void set_word(const size_t start_pos, const std::string& word, const uint16_t length);
+    void set_words_f(std::vector<WordsFValue>& words_f);
+    void set_additional(const AdditionalBlock& additional_block, size_t additional_id);
+    void set_reversed(const ReversedBlock& reversed_block, size_t word_id);
   };
 
 private:
@@ -78,12 +88,12 @@ private:
   static bool readonly_initialized;
   static bool is_mapped;
   static bool first_time;
-  static int64_t paths_size_buffer;
-  static int64_t paths_count_size_buffer;
-  static int64_t words_size_buffer;
-  static int64_t words_f_size_buffer;
-  static int64_t reversed_size_buffer;
-  static int64_t additional_size_buffer;
+  static size_t paths_size_buffer;
+  static size_t paths_count_size_buffer;
+  static size_t words_size_buffer;
+  static size_t words_f_size_buffer;
+  static size_t reversed_size_buffer;
+  static size_t additional_size_buffer;
 
 
   static bool index_lock;

--- a/app/Index/index.h
+++ b/app/Index/index.h
@@ -37,6 +37,7 @@ private:
     bool is_locked;
 
     bool map_file(mio::mmap_sink& target_mmap, size_t& target_size, const std::string& source_path);
+    bool sync_file(mio::mmap_sink& target_mmap);
 
   public:
     DiskIO();
@@ -47,6 +48,7 @@ private:
     bool unmap();
     // unmaps the index files.
     // returns true if successful , false if not
+    bool sync_all();
 
 
     // getters
@@ -76,24 +78,13 @@ private:
   static bool readonly_initialized;
   static bool is_mapped;
   static bool first_time;
-  static int64_t paths_size;
   static int64_t paths_size_buffer;
-  static int64_t paths_count_size;
   static int64_t paths_count_size_buffer;
-  static int64_t words_size;
   static int64_t words_size_buffer;
-  static int64_t words_f_size;
   static int64_t words_f_size_buffer;
-  static int64_t reversed_size;
   static int64_t reversed_size_buffer;
-  static int64_t additional_size;
   static int64_t additional_size_buffer;
-  static mio::mmap_sink mmap_paths;
-  static mio::mmap_sink mmap_paths_count;
-  static mio::mmap_sink mmap_words;
-  static mio::mmap_sink mmap_words_f;
-  static mio::mmap_sink mmap_reversed;
-  static mio::mmap_sink mmap_additional;
+
 
   static bool index_lock;
   static bool read_only;
@@ -104,9 +95,7 @@ private:
 
 private:
   static void check_files();
-  static int map();
   static int sync_all();
-  static int unmap();
   static void resize(const std::filesystem::path path_to_resize,
                      const size_t size);
   static int add_new(index_combine_data& index_to_add);

--- a/app/Index/index.h
+++ b/app/Index/index.h
@@ -113,7 +113,6 @@ private:
   static std::string generate_new_additionals(index_combine_data& index_to_add, const size_t& local_word_count,
                                               PathsMapping& paths_mapping, uint32_t& current_additional);
   static void add_reversed_to_word(index_combine_data& index_to_add,
-                                   uint64_t& on_disk_count,
                                    std::vector<Transaction>& transactions,
                                    size_t& additional_new_needed_size,
                                    size_t& reversed_new_needed_size,

--- a/app/Index/index.h
+++ b/app/Index/index.h
@@ -37,6 +37,7 @@ class Index
     bool map_file(mio::mmap_sink& target_mmap, size_t& target_size, const std::string& source_path);
     bool sync_file(mio::mmap_sink& target_mmap) const;
     mio::mmap_sink* get_target_mmap(uint8_t target_index);
+    size_t get_target_size(const uint8_t target_index) const;
 
   public:
     DiskIO();

--- a/app/Index/index.h
+++ b/app/Index/index.h
@@ -155,7 +155,7 @@ public:
   search_word_list(std::vector<std::pair<std::string, bool>>& search_words,
                    int min_char_for_match);
   static std::unordered_map<PATH_ID_TYPE, std::string>
-  id_to_path_string(std::vector<search_path_ids_return> path_ids);
+  id_to_path_string(std::vector<search_path_ids_return>& path_ids);
 
   static int lock_status(bool initialize);
   static bool lock(bool initialize);


### PR DESCRIPTION
Separate direct disk access into a subclass to improve readability and maintainability as-well as making the code more robust


TODO:
- [x] migrate all sizes to new functions
- [x] migrate lock and mapped functions
- [x] migrate access on other files
- [x] migrate mapping and unmapping to diskio
- [ ] map and unmap is called quite a bit
- [ ] improve reibterpret usage, use safer operations
- [x] usng inline functions for io?
- [ ] in debug builds do bounds checking for all IO operations on input and on mmap
- [ ] helper functions improvement to give back errors correctly


maybe?
- inline functions
- bounds validation when accessing (performance? maybe just in debug)
- also improve locking and health situation (#156 )